### PR TITLE
feat: add dapr infra kustomization

### DIFF
--- a/infra/dapr/README.md
+++ b/infra/dapr/README.md
@@ -1,0 +1,67 @@
+# stuttgart-things/flux/infra/dapr
+
+Installs the [Dapr](https://dapr.io) runtime on the cluster via the official
+[Dapr Helm chart](https://artifacthub.io/packages/helm/dapr/dapr). Provides the
+workflow engine, state store abstraction, and sidecar injector used by the
+workflow apps in this repository (e.g. `backstage-template-execution`).
+
+## REQUIREMENTS
+
+<details><summary>ADD GITREPOSITORY</summary>
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    tag: v1.0.0
+  url: https://github.com/stuttgart-things/flux.git
+EOF
+```
+
+</details>
+
+## KUSTOMIZATION
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dapr
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./infra/dapr
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      DAPR_VERSION: 1.17.4
+      DAPR_NAMESPACE: dapr-system
+      DAPR_HA_ENABLED: "false"
+EOF
+```
+
+## VARIABLES
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DAPR_VERSION` | `1.17.4` | Dapr helm chart version (matches runtime version) |
+| `DAPR_NAMESPACE` | `dapr-system` | Namespace for Dapr control-plane components |
+| `DAPR_HA_ENABLED` | `false` | High-availability mode for control-plane (3 replicas per component) |
+
+Per-app Dapr components (state stores, pubsub, etc.) are not installed here —
+they live with the app that uses them (e.g. `apps/backstage-template-execution/`)
+so each app can bring its own Redis / component configuration.

--- a/infra/dapr/kustomization.yaml
+++ b/infra/dapr/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml

--- a/infra/dapr/release.yaml
+++ b/infra/dapr/release.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dapr
+  namespace: ${DAPR_NAMESPACE:-dapr-system}
+spec:
+  interval: 20m
+  chart:
+    spec:
+      chart: dapr
+      version: ${DAPR_VERSION:-1.17.4}
+      sourceRef:
+        kind: HelmRepository
+        name: dapr
+        namespace: ${DAPR_NAMESPACE:-dapr-system}
+      interval: 12h
+  values:
+    global:
+      ha:
+        enabled: ${DAPR_HA_ENABLED:-false}
+      logAsJson: true
+    dapr_operator:
+      logLevel: info
+    dapr_placement:
+      logLevel: info
+    dapr_sidecar_injector:
+      logLevel: info
+    dapr_scheduler:
+      logLevel: info

--- a/infra/dapr/requirements.yaml
+++ b/infra/dapr/requirements.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${DAPR_NAMESPACE:-dapr-system}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dapr
+  namespace: ${DAPR_NAMESPACE:-dapr-system}
+spec:
+  interval: 24h
+  url: https://dapr.github.io/helm-charts/


### PR DESCRIPTION
## Summary
- New `infra/dapr/` following the same layout as `infra/cert-manager/` (requirements + release + kustomization + README)
- Installs Dapr control-plane via the official helm chart from https://dapr.github.io/helm-charts/
- Pinned to **1.17.4** to match the runtime version the workflow apps in `dapr-workflows` were developed against
- Parameterized on `DAPR_VERSION`, `DAPR_NAMESPACE`, `DAPR_HA_ENABLED`
- README documents the postBuild substitutions and explains that per-app state store components stay with the app

No post-release.yaml — Dapr install has no secrets to pass, and per-app components (Redis state store, etc.) belong with each workload so each app can bring its own config.

## Test plan
- [ ] Apply the Kustomization against a test cluster and confirm `dapr-system` namespace comes up with operator/placement/sidecar-injector/scheduler pods ready
- [ ] Confirm `kubectl get components.dapr.io -A` works (CRDs installed)
- [ ] Label a test namespace and inject a sidecar into a trivial pod to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)