### PR TITLE
feat: add dapr-workflow-service external access for backstage

### DIFF
--- a/apps/backstage/README.md
+++ b/apps/backstage/README.md
@@ -49,6 +49,7 @@ stringData:
   BACKSTAGE_GITHUB_CLIENT_SECRET: "9c20..."                   #pragma: allowlist secret
   BACKSTAGE_BACKEND_SECRET: "backstage-backend-secret-key-…"  #pragma: allowlist secret
   BACKSTAGE_POSTGRESQL_PASSWORD: "backstage"                  #pragma: allowlist secret
+  BACKSTAGE_DAPR_SERVICE_TOKEN: "c2Wc7O/7EAxNhMd9…"            #pragma: allowlist secret
 ```
 
 ```bash
@@ -217,6 +218,7 @@ stringData:
   BACKSTAGE_GITHUB_CLIENT_SECRET: "..."                       #pragma: allowlist secret
   BACKSTAGE_BACKEND_SECRET: "..."                             #pragma: allowlist secret
   BACKSTAGE_POSTGRESQL_PASSWORD: "..."                        #pragma: allowlist secret
+  BACKSTAGE_DAPR_SERVICE_TOKEN: "..."                         #pragma: allowlist secret
 ```
 
 ### backstage.yaml
@@ -293,6 +295,7 @@ spec:
 | `BACKSTAGE_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret |
 | `BACKSTAGE_BACKEND_SECRET` | Signing key for Backstage backend auth |
 | `BACKSTAGE_POSTGRESQL_PASSWORD` | Password for the bundled PostgreSQL instance |
+| `BACKSTAGE_DAPR_SERVICE_TOKEN` | Static external-access token for the `dapr-workflow-service` subject (restricted to `scaffolder` + `catalog` plugins). Consumed by the dapr-workflows/backstage-template-execution app. |
 
 ### Helm Override (set in `backstage-helm-overrides` ConfigMap)
 

--- a/apps/backstage/pre-release.yaml
+++ b/apps/backstage/pre-release.yaml
@@ -30,6 +30,14 @@ spec:
             auth:
               keys:
                 - secret: $${BACKEND_SECRET:-change-me-in-production}
+              externalAccess:
+                - type: static
+                  options:
+                    token: $${DAPR_SERVICE_TOKEN}
+                    subject: dapr-workflow-service
+                  accessRestrictions:
+                    - plugin: scaffolder
+                    - plugin: catalog
             baseUrl: $${BACKEND_BASE_URL:-http://localhost:7007}
             listen:
               port: $${BACKEND_PORT:-7007}
@@ -115,3 +123,4 @@ spec:
           GITHUB_CLIENT_ID: ${BACKSTAGE_GITHUB_CLIENT_ID}
           GITHUB_CLIENT_SECRET: ${BACKSTAGE_GITHUB_CLIENT_SECRET}
           BACKEND_SECRET: ${BACKSTAGE_BACKEND_SECRET}
+          DAPR_SERVICE_TOKEN: ${BACKSTAGE_DAPR_SERVICE_TOKEN}

--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -102,6 +102,11 @@ spec:
             secretKeyRef:
               name: backstage-secrets
               key: BACKEND_SECRET
+        - name: DAPR_SERVICE_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: backstage-secrets
+              key: DAPR_SERVICE_TOKEN
       extraAppConfig:
         - filename: app-config.extra.yaml
           configMapRef: backstage-app-config


### PR DESCRIPTION
## Summary
Adds a static external-access entry under `backend.auth` in the Backstage app-config so the dapr-workflows `backstage-template-execution` app can authenticate to the Scaffolder and Catalog APIs.

## Changes
- **`apps/backstage/pre-release.yaml`**:
  - New `backend.auth.externalAccess` block with `subject: dapr-workflow-service`, token from `$${DAPR_SERVICE_TOKEN}`, and `accessRestrictions` limiting access to the `scaffolder` + `catalog` plugins.
  - New `DAPR_SERVICE_TOKEN` entry in `secretKVs`, substituted from the flux `BACKSTAGE_DAPR_SERVICE_TOKEN` secret var.
- **`apps/backstage/release.yaml`**: new `DAPR_SERVICE_TOKEN` `extraEnvVars` entry sourced from the `backstage-secrets` Secret.
- **`apps/backstage/README.md`**: documented `BACKSTAGE_DAPR_SERVICE_TOKEN` in both secret-declaration blocks and the variables table.

## Why restrict to `scaffolder` + `catalog`?
The dapr workflow needs:
- `scaffolder` — to `POST /api/scaffolder/v2/tasks` (start template) and `GET /api/scaffolder/v2/tasks/{id}` (poll status)
- `catalog` — to `GET /api/catalog/entities/by-name/template/...` when running the `/dry-run` endpoint, which needs the template entity inline

Without both, dry-run returns `403 This token's access is restricted to plugin(s) 'scaffolder'`.

## Test plan
- [ ] Set `BACKSTAGE_DAPR_SERVICE_TOKEN` in the flux secret for Backstage
- [ ] Reconcile the flux Kustomization; confirm `backstage-secrets` Secret has the new key and the pod has the env var
- [ ] From the dapr-workflows worker, run `./run.sh` and confirm scaffolder task creation succeeds (no 401)
- [ ] Run `./run.sh` with `dryRun: true` and confirm the catalog fetch succeeds (no 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)