### PR TITLE
fix: rename DAPR_SERVICE_TOKEN to EXTERNAL_ACCESS_TOKEN

### DIFF
--- a/apps/backstage/README.md
+++ b/apps/backstage/README.md
@@ -49,7 +49,7 @@ stringData:
   BACKSTAGE_GITHUB_CLIENT_SECRET: "9c20..."                   #pragma: allowlist secret
   BACKSTAGE_BACKEND_SECRET: "backstage-backend-secret-key-…"  #pragma: allowlist secret
   BACKSTAGE_POSTGRESQL_PASSWORD: "backstage"                  #pragma: allowlist secret
-  BACKSTAGE_DAPR_SERVICE_TOKEN: "c2Wc7O/7EAxNhMd9…"            #pragma: allowlist secret
+  BACKSTAGE_EXTERNAL_ACCESS_TOKEN: "c2Wc7O/7EAxNhMd9…"            #pragma: allowlist secret
 ```
 
 ```bash
@@ -218,7 +218,7 @@ stringData:
   BACKSTAGE_GITHUB_CLIENT_SECRET: "..."                       #pragma: allowlist secret
   BACKSTAGE_BACKEND_SECRET: "..."                             #pragma: allowlist secret
   BACKSTAGE_POSTGRESQL_PASSWORD: "..."                        #pragma: allowlist secret
-  BACKSTAGE_DAPR_SERVICE_TOKEN: "..."                         #pragma: allowlist secret
+  BACKSTAGE_EXTERNAL_ACCESS_TOKEN: "..."                         #pragma: allowlist secret
 ```
 
 ### backstage.yaml
@@ -295,7 +295,7 @@ spec:
 | `BACKSTAGE_GITHUB_CLIENT_SECRET` | GitHub OAuth App client secret |
 | `BACKSTAGE_BACKEND_SECRET` | Signing key for Backstage backend auth |
 | `BACKSTAGE_POSTGRESQL_PASSWORD` | Password for the bundled PostgreSQL instance |
-| `BACKSTAGE_DAPR_SERVICE_TOKEN` | Static external-access token for the `dapr-workflow-service` subject (restricted to `scaffolder` + `catalog` plugins). Consumed by the dapr-workflows/backstage-template-execution app. |
+| `BACKSTAGE_EXTERNAL_ACCESS_TOKEN` | Static external-access token for the `dapr-workflow-service` subject (restricted to `scaffolder` + `catalog` plugins). Consumed by the dapr-workflows/backstage-template-execution app. |
 
 ### Helm Override (set in `backstage-helm-overrides` ConfigMap)
 

--- a/apps/backstage/pre-release.yaml
+++ b/apps/backstage/pre-release.yaml
@@ -33,7 +33,7 @@ spec:
               externalAccess:
                 - type: static
                   options:
-                    token: $${DAPR_SERVICE_TOKEN}
+                    token: $${EXTERNAL_ACCESS_TOKEN}
                     subject: dapr-workflow-service
                   accessRestrictions:
                     - plugin: scaffolder
@@ -123,4 +123,4 @@ spec:
           GITHUB_CLIENT_ID: ${BACKSTAGE_GITHUB_CLIENT_ID}
           GITHUB_CLIENT_SECRET: ${BACKSTAGE_GITHUB_CLIENT_SECRET}
           BACKEND_SECRET: ${BACKSTAGE_BACKEND_SECRET}
-          DAPR_SERVICE_TOKEN: ${BACKSTAGE_DAPR_SERVICE_TOKEN}
+          EXTERNAL_ACCESS_TOKEN: ${BACKSTAGE_EXTERNAL_ACCESS_TOKEN}

--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -102,11 +102,11 @@ spec:
             secretKeyRef:
               name: backstage-secrets
               key: BACKEND_SECRET
-        - name: DAPR_SERVICE_TOKEN
+        - name: EXTERNAL_ACCESS_TOKEN
           valueFrom:
             secretKeyRef:
               name: backstage-secrets
-              key: DAPR_SERVICE_TOKEN
+              key: EXTERNAL_ACCESS_TOKEN
       extraAppConfig:
         - filename: app-config.extra.yaml
           configMapRef: backstage-app-config


### PR DESCRIPTION
## Summary
Rename the env var / secret key / flux substitution var from `DAPR_SERVICE_TOKEN` → `EXTERNAL_ACCESS_TOKEN` so the plumbing can be reused for additional Backstage backend external-access consumers later (not just dapr-workflow-service).

## Changes
- `pre-release.yaml`: `$${DAPR_SERVICE_TOKEN}` → `$${EXTERNAL_ACCESS_TOKEN}`, secretKVs key + flux var both renamed
- `release.yaml`: `extraEnvVars` entry renamed
- `README.md`: variable table + secret declaration blocks updated

## Not renamed
- `subject: dapr-workflow-service` stays as-is — it's the correct identity for *this* consumer. Additional future consumers will get their own `externalAccess` list entry with a distinct subject.

## Required follow-up in the cluster repo
The SOPS-encrypted secret `clusters/labul/vsphere/platform-sthings/apps/backstage-secrets.enc.yaml` currently has the key misnamed `DAPR_SERVICE_TOKEN` (without the `BACKSTAGE_` prefix, which was the original bug that blocked the previous PR). Before merging this PR:

1. `sops backstage-secrets.enc.yaml`
2. rename `DAPR_SERVICE_TOKEN` → `BACKSTAGE_EXTERNAL_ACCESS_TOKEN`
3. commit + push to stuttgart-things

Then merge this PR and let flux reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)