### PR TITLE
feat: add dapr-backstage-template-execution flux app

### DIFF
--- a/apps/dapr-backstage-template-execution/README.md
+++ b/apps/dapr-backstage-template-execution/README.md
@@ -1,0 +1,180 @@
+# stuttgart-things/flux/dapr-backstage-template-execution
+
+Flux app for the `backstage-template-execution` Dapr workflow — triggers a
+Backstage scaffolder template, polls the task, watches the resulting GitHub
+Actions run on the opened PR, and optionally merges the PR.
+
+Deployed via OCI kustomize base (built from KCL manifests in
+`dapr-workflows/backstage-template-execution/deploy`).
+
+## Kustomization Example
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dapr-backstage-template-execution
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: stuttgart-things-flux
+  path: ./apps/dapr-backstage-template-execution
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      DAPR_BACKSTAGE_TPL_NAMESPACE: backstage-workflows
+      DAPR_BACKSTAGE_TPL_VERSION: 60b81b0cbb6b
+      DAPR_BACKSTAGE_TPL_IMAGE_TAG: 60b81b0cbb6b
+    substituteFrom:
+      - kind: Secret
+        name: dapr-backstage-template-execution-vars
+EOF
+```
+
+The `dapr-backstage-template-execution-vars` Secret must provide:
+
+| Key | Purpose |
+|---|---|
+| `GITHUB_TOKEN` | PAT with `repo` scope — used by `FetchGitHubRun` / `MergePullRequest` activities |
+| `BACKSTAGE_AUTH_TOKEN` | Bearer token for the Backstage scaffolder API |
+| `REDIS_PASSWORD` | Password for the Dapr state store / pub-sub Redis |
+
+### Example Secret
+
+Create it in the same namespace as the Flux Kustomization (typically
+`flux-system`) so `substituteFrom` can resolve it. In production, encrypt
+with SOPS / Sealed Secrets instead of committing the plain values.
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dapr-backstage-template-execution-vars
+  namespace: flux-system
+type: Opaque
+stringData:
+  GITHUB_TOKEN: ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  BACKSTAGE_AUTH_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+  REDIS_PASSWORD: super-secret-redis-password
+```
+
+Or on the fly:
+
+```bash
+kubectl create secret generic dapr-backstage-template-execution-vars \
+  --namespace flux-system \
+  --from-literal=GITHUB_TOKEN="$GITHUB_TOKEN" \
+  --from-literal=BACKSTAGE_AUTH_TOKEN="$BACKSTAGE_AUTH_TOKEN" \
+  --from-literal=REDIS_PASSWORD="$REDIS_PASSWORD"
+```
+
+## Triggering a workflow run (user-supplied input)
+
+The app only runs the *worker*; an actual workflow instance is triggered by
+POSTing a JSON payload — equivalent to
+`dapr-workflows/backstage-template-execution/input.json` — to the Dapr
+sidecar's workflow API. This input is **not** part of the flux app; it's
+user-supplied at run time, same as the secret above. Typical pattern is a
+ConfigMap holding `input.json` plus a `Job` that curls the sidecar.
+
+The in-cluster sidecar is reachable at
+`http://backstage-template-execution-dapr.<namespace>.svc.cluster.local:3500`
+once the Deployment is running.
+
+### Example ConfigMap + trigger Job
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dapr-backstage-tpl-input
+  namespace: backstage-workflows
+data:
+  input.json: |
+    {
+      "backstageURL": "https://backstage.platform.sthings-vsphere.labul.sva.de",
+      "templateRef": "template:default/create-terraform-vm",
+      "dryRun": false,
+      "values": {
+        "lab": "LabUL",
+        "cloud": "proxmox",
+        "vm_name": "dapr-monday-1"
+      },
+      "watch": {
+        "owner": "stuttgart-things",
+        "repo": "stuttgart-things",
+        "workflowFile": "pr-vm-deploy.yaml",
+        "branch": "proxmox-vm-dapr-monday-1-labul",
+        "timeoutMin": 30,
+        "merge": {"enabled": true, "method": "squash"}
+      }
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: trigger-backstage-tpl-create-vm
+  namespace: backstage-workflows
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: input
+          configMap:
+            name: dapr-backstage-tpl-input
+      containers:
+        - name: trigger
+          image: curlimages/curl:8.11.1
+          volumeMounts:
+            - name: input
+              mountPath: /input
+              readOnly: true
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              INSTANCE_ID="run-$(date +%s)"
+              SIDECAR="http://backstage-template-execution-dapr.backstage-workflows.svc.cluster.local:3500"
+              echo "starting workflow instance: $INSTANCE_ID"
+              curl -sS -X POST \
+                "${SIDECAR}/v1.0-beta1/workflows/dapr/BackstageTemplateWorkflow/start?instanceID=${INSTANCE_ID}" \
+                -H "Content-Type: application/json" \
+                --data-binary @/input/input.json
+              echo
+              echo "instance started: $INSTANCE_ID"
+```
+
+Apply both, then watch the worker pod logs or poll
+`${SIDECAR}/v1.0-beta1/workflows/dapr/<instanceID>` for status. The same
+`input.json` format as the local `run.sh` workflow — the worker env var
+fallbacks (`BACKSTAGE_AUTH_TOKEN`) mean you don't need to embed tokens
+in the payload.
+
+For a scheduled run, swap `Job` for `CronJob`.
+
+## Layout
+
+- `requirements.yaml` — Namespace + OCIRepository pointing at the pushed kustomize base
+- `release.yaml` — Flux Kustomization; overrides image tag and deletes the placeholder Secrets / CA ConfigMap that ship in the base
+- `secrets.yaml` — real Secrets resolved via `substituteFrom` (GITHUB_TOKEN, BACKSTAGE_AUTH_TOKEN, REDIS_PASSWORD)
+- `kustomization.yaml` — glues the above together
+
+## Versioning
+
+The OCI artifact is built by `task build-scan-image-ko` in the
+`dapr-workflows` repo, which also pushes a kustomize base tagged with the
+same short random tag as the container image (e.g. `60b81b0cbb6b`). Bump
+`DAPR_BACKSTAGE_TPL_VERSION` (OCI artifact tag) and
+`DAPR_BACKSTAGE_TPL_IMAGE_TAG` (container image tag) together.

--- a/apps/dapr-backstage-template-execution/kustomization.yaml
+++ b/apps/dapr-backstage-template-execution/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml
+  - secrets.yaml

--- a/apps/dapr-backstage-template-execution/release.yaml
+++ b/apps/dapr-backstage-template-execution/release.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dapr-backstage-template-execution
+  namespace: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: OCIRepository
+    name: dapr-backstage-template-execution-kustomize
+  prune: true
+  wait: true
+  targetNamespace: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+  patches:
+    # Override the container image tag
+    - target:
+        kind: Deployment
+        name: backstage-template-execution
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: backstage-template-execution
+        spec:
+          template:
+            spec:
+              containers:
+                - name: workflow
+                  image: ghcr.io/stuttgart-things/dapr-backstage-template-execution:${DAPR_BACKSTAGE_TPL_IMAGE_TAG:-60b81b0cbb6b}
+    # Drop placeholder Secrets from the kustomize base — real secrets come
+    # from this flux app (see secrets.yaml) so they can be managed via SOPS
+    # or substituteFrom.
+    - target:
+        kind: Secret
+        name: github-token
+      patch: |
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: github-token
+        $patch: delete
+    - target:
+        kind: Secret
+        name: backstage-auth-token
+      patch: |
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: backstage-auth-token
+        $patch: delete
+    - target:
+        kind: Secret
+        name: redis-password
+      patch: |
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: redis-password
+        $patch: delete
+    # Drop the placeholder CA ConfigMap from the kustomize base; provide the
+    # real CA via substituteFrom or disable CA mount at build time.
+    - target:
+        kind: ConfigMap
+        name: backstage-ca
+      patch: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: backstage-ca
+        $patch: delete

--- a/apps/dapr-backstage-template-execution/requirements.yaml
+++ b/apps/dapr-backstage-template-execution/requirements.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/${FLUX_SOURCE_API_VERSION:-v1}
+kind: OCIRepository
+metadata:
+  name: dapr-backstage-template-execution-kustomize
+  namespace: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+spec:
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things/dapr-backstage-template-execution-kustomize
+  ref:
+    tag: ${DAPR_BACKSTAGE_TPL_VERSION:-60b81b0cbb6b}

--- a/apps/dapr-backstage-template-execution/secrets.yaml
+++ b/apps/dapr-backstage-template-execution/secrets.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+  namespace: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+type: Opaque
+stringData:
+  token: ${GITHUB_TOKEN}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backstage-auth-token
+  namespace: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+type: Opaque
+stringData:
+  token: ${BACKSTAGE_AUTH_TOKEN}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-password
+  namespace: ${DAPR_BACKSTAGE_TPL_NAMESPACE:-backstage-workflows}
+type: Opaque
+stringData:
+  password: ${REDIS_PASSWORD}


### PR DESCRIPTION
## Summary

- Adds `apps/dapr-backstage-template-execution/` — flux app for the `backstage-template-execution` Dapr workflow worker, following the clusterbook pattern
- Pulls the deployment manifests from the OCI kustomize base published by `dapr-workflows/backstage-template-execution/deploy`
- Overrides the container image tag + deletes placeholder Secrets/ConfigMap from the base; real Secrets come in via `substituteFrom`
- Documents the user-supplied workflow input (ConfigMap + trigger Job) as a runtime concern, same as the credentials Secret

## Test plan

- [x] `kubectl kustomize apps/dapr-backstage-template-execution/` renders cleanly
- [ ] Apply the Flux Kustomization in a cluster and verify the worker pod reaches ready
- [ ] Apply the example trigger Job from the README and verify a workflow instance starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)