### PR TITLE
feat: add kargo helm app

### DIFF
--- a/apps/kargo/README.md
+++ b/apps/kargo/README.md
@@ -38,7 +38,7 @@ spec:
   postBuild:
     substitute:
       KARGO_NAMESPACE: kargo
-      KARGO_VERSION: "1.3.0"
+      KARGO_VERSION: "1.9.6"
       KARGO_HOSTNAME: kargo
       KARGO_DOMAIN: example.sthings-vsphere.example.com
       KARGO_ADMIN_PASSWORD_HASH: "<bcrypt-hash>"

--- a/apps/kargo/README.md
+++ b/apps/kargo/README.md
@@ -1,0 +1,109 @@
+# stuttgart-things/flux/kargo
+
+Deploys [Kargo](https://github.com/akuity/kargo) from the Akuity OCI Helm registry
+(`oci://ghcr.io/akuity/kargo-charts/kargo`) via Flux.
+
+Equivalent of:
+
+```bash
+helm install kargo \
+  oci://ghcr.io/akuity/kargo-charts/kargo \
+  --namespace kargo \
+  --create-namespace \
+  --set api.adminAccount.passwordHash=$hashed_pass \
+  --set api.adminAccount.tokenSigningKey=$signing_key \
+  --wait
+```
+
+## Main Kargo Deployment
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kargo
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./apps/kargo
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      KARGO_NAMESPACE: kargo
+      KARGO_VERSION: "1.3.0"
+      KARGO_HOSTNAME: kargo
+      KARGO_DOMAIN: example.sthings-vsphere.example.com
+      KARGO_ADMIN_PASSWORD_HASH: "<bcrypt-hash>"
+      KARGO_ADMIN_TOKEN_SIGNING_KEY: "<random-signing-key>"
+      KARGO_ADMIN_TOKEN_TTL: 24h
+      KARGO_SERVICE_TYPE: ClusterIP
+      KARGO_API_TLS_ENABLED: "false"
+      KARGO_INGRESS_TLS_ENABLED: "true"
+      KARGO_LOG_LEVEL: INFO
+      KARGO_WEBHOOKS_SELF_SIGNED_CERT: "true"
+      INGRESS_ENABLED: "false"
+      INGRESS_CLASS_NAME: nginx
+      ISSUER_NAME: cluster-issuer-approle
+      ISSUER_KIND: ClusterIssuer
+EOF
+```
+
+## Generating admin credentials
+
+```bash
+# Password hash (bcrypt)
+htpasswd -bnBC 10 "" <your-password> | tr -d ':\n' | sed 's/$2y/$2a/'
+
+# Token signing key
+openssl rand -base64 29 | tr -d "=+/" | head -c 32
+```
+
+## Optional: HTTPRoute (Gateway API)
+
+Deploys a Gateway API `HTTPRoute` for kargo instead of using the Helm chart's
+built-in ingress. Keep `INGRESS_ENABLED: "false"` in the main Kustomization and
+add a second one for the HTTPRoute.
+
+| Variable | Default | Description |
+|---|---|---|
+| `KARGO_NAMESPACE` | `kargo` | Target namespace |
+| `GATEWAY_NAME` | `cilium-gateway` | Gateway resource name |
+| `GATEWAY_NAMESPACE` | `default` | Namespace of the Gateway resource |
+| `KARGO_HOSTNAME` | `kargo` | Hostname prefix |
+| `KARGO_DOMAIN` | *(required)* | Domain suffix |
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kargo-httproute
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./apps/kargo/httproute
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      KARGO_NAMESPACE: kargo
+      GATEWAY_NAME: cilium-gateway
+      GATEWAY_NAMESPACE: default
+      KARGO_HOSTNAME: kargo
+      KARGO_DOMAIN: example.com
+EOF
+```

--- a/apps/kargo/httproute/httproute.yaml
+++ b/apps/kargo/httproute/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kargo
+  namespace: ${KARGO_NAMESPACE:-kargo}
+spec:
+  parentRefs:
+    - name: ${GATEWAY_NAME:-cilium-gateway}
+      namespace: ${GATEWAY_NAMESPACE:-default}
+  hostnames:
+    - "${KARGO_HOSTNAME:-kargo}.${KARGO_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: kargo-api
+          port: 443

--- a/apps/kargo/httproute/kustomization.yaml
+++ b/apps/kargo/httproute/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - httproute.yaml

--- a/apps/kargo/kustomization.yaml
+++ b/apps/kargo/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - pre-release.yaml
+  - release.yaml

--- a/apps/kargo/pre-release.yaml
+++ b/apps/kargo/pre-release.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kargo-certificate-configuration
+  namespace: ${KARGO_NAMESPACE:-kargo}
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: sthings-cluster
+      version: 0.3.20
+      sourceRef:
+        kind: HelmRepository
+        name: stuttgart-things
+        namespace: ${KARGO_NAMESPACE:-kargo}
+      interval: 12h
+  values:
+    customresources:
+      ingress-certificate-kargo:
+        apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: kargo-ingress
+          namespace: ${KARGO_NAMESPACE:-kargo}
+        spec:
+          commonName: ${KARGO_HOSTNAME:-kargo}.${KARGO_DOMAIN}
+          dnsNames:
+            - ${KARGO_HOSTNAME:-kargo}.${KARGO_DOMAIN}
+          issuerRef:
+            name: ${ISSUER_NAME}
+            kind: ${ISSUER_KIND:-ClusterIssuer}
+          secretName: ${KARGO_HOSTNAME:-kargo}.${KARGO_DOMAIN}-tls

--- a/apps/kargo/release.yaml
+++ b/apps/kargo/release.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kargo
+  namespace: ${KARGO_NAMESPACE:-kargo}
+spec:
+  dependsOn:
+    - name: kargo-certificate-configuration
+      namespace: ${KARGO_NAMESPACE:-kargo}
+  interval: 30m
+  timeout: 10m
+  chart:
+    spec:
+      chart: kargo
+      version: ${KARGO_VERSION:-1.3.0}
+      sourceRef:
+        kind: HelmRepository
+        name: akuity
+        namespace: ${KARGO_NAMESPACE:-kargo}
+      interval: 12h
+  values:
+    api:
+      host: ${KARGO_HOSTNAME:-kargo}.${KARGO_DOMAIN}
+      adminAccount:
+        passwordHash: ${KARGO_ADMIN_PASSWORD_HASH}
+        tokenSigningKey: ${KARGO_ADMIN_TOKEN_SIGNING_KEY}
+        tokenTTL: ${KARGO_ADMIN_TOKEN_TTL:-24h}
+      service:
+        type: ${KARGO_SERVICE_TYPE:-ClusterIP}
+      tls:
+        enabled: ${KARGO_API_TLS_ENABLED:-false}
+      ingress:
+        enabled: ${INGRESS_ENABLED:-false}
+        ingressClassName: ${INGRESS_CLASS_NAME:-nginx}
+        tls:
+          enabled: ${KARGO_INGRESS_TLS_ENABLED:-true}
+        annotations:
+          cert-manager.io/cluster-issuer: ${ISSUER_NAME}
+    controller:
+      logLevel: ${KARGO_LOG_LEVEL:-INFO}
+    webhooksServer:
+      tls:
+        selfSignedCert: ${KARGO_WEBHOOKS_SELF_SIGNED_CERT:-true}
+    garbageCollector:
+      logLevel: ${KARGO_LOG_LEVEL:-INFO}

--- a/apps/kargo/release.yaml
+++ b/apps/kargo/release.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: kargo
-      version: ${KARGO_VERSION:-1.3.0}
+      version: ${KARGO_VERSION:-1.9.6}
       sourceRef:
         kind: HelmRepository
         name: akuity

--- a/apps/kargo/requirements.yaml
+++ b/apps/kargo/requirements.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${KARGO_NAMESPACE:-kargo}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: akuity
+  namespace: ${KARGO_NAMESPACE:-kargo}
+spec:
+  type: oci
+  interval: 1h
+  url: oci://ghcr.io/akuity/kargo-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: stuttgart-things
+  namespace: ${KARGO_NAMESPACE:-kargo}
+spec:
+  type: oci
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things


### PR DESCRIPTION
## Summary
- Adds `apps/kargo/` as a new Flux app sourced from `oci://ghcr.io/akuity/kargo-charts` (chart `kargo`), pinned to `v1.9.6` by default.
- Wires `api.adminAccount.passwordHash` and `api.adminAccount.tokenSigningKey` through `${KARGO_ADMIN_PASSWORD_HASH}` / `${KARGO_ADMIN_TOKEN_SIGNING_KEY}` substitution variables, equivalent to the upstream `helm install kargo ... --set api.adminAccount.passwordHash=... --set api.adminAccount.tokenSigningKey=...` invocation.
- Follows the existing app structure: `requirements.yaml` (namespace + `akuity` and `stuttgart-things` `HelmRepository`s), `pre-release.yaml` (cert-manager `Certificate` via the `sthings-cluster` helper chart), `release.yaml` (main `HelmRelease` with `dependsOn` the certificate), optional `httproute/` Gateway API overlay, and a `README.md`.

## Test plan
- [ ] `kubectl apply` the Flux `Kustomization` from `apps/kargo/README.md` against a test cluster with `KARGO_ADMIN_PASSWORD_HASH`, `KARGO_ADMIN_TOKEN_SIGNING_KEY`, `KARGO_DOMAIN`, and `ISSUER_NAME` set.
- [ ] Verify the `kargo-certificate-configuration` `HelmRelease` reconciles and the `Certificate` becomes Ready.
- [ ] Verify the `kargo` `HelmRelease` reconciles and kargo pods come up healthy.
- [ ] Optionally apply `apps/kargo/httproute` and verify the `HTTPRoute` attaches to the configured gateway and the Kargo UI is reachable.
- [ ] Log in to the Kargo UI with the admin password matching the provided bcrypt hash.