### PR TITLE
feat: add argo-rollouts cicd app

### DIFF
--- a/cicd/argo-rollouts/README.md
+++ b/cicd/argo-rollouts/README.md
@@ -1,0 +1,107 @@
+# stuttgart-things/flux/cicd/argo-rollouts
+
+Deploys [Argo Rollouts](https://argo-rollouts.readthedocs.io/) from the
+`argo-helm` repository (`https://argoproj.github.io/argo-helm`, chart
+`argo-rollouts`) via Flux, including the dashboard exposed through a Gateway
+API `HTTPRoute`.
+
+Equivalent of:
+
+```bash
+helm repo add argo https://argoproj.github.io/argo-helm
+helm install argo-rollouts argo/argo-rollouts \
+  --version 2.40.9 \
+  --create-namespace \
+  --namespace argo-rollouts \
+  --wait
+```
+
+## REQUIREMENTS
+
+<details><summary>ADD GITREPOSITORY</summary>
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/stuttgart-things/flux.git
+EOF
+```
+
+</details>
+
+## KUSTOMIZATION
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: argo-rollouts
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./cicd/argo-rollouts
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      ARGO_ROLLOUTS_NAMESPACE: argo-rollouts
+      ARGO_ROLLOUTS_VERSION: "2.40.9"
+      ARGO_ROLLOUTS_INSTALL_CRDS: "true"
+      ARGO_ROLLOUTS_KEEP_CRDS: "true"
+      ARGO_ROLLOUTS_CLUSTER_INSTALL: "true"
+      ARGO_ROLLOUTS_CREATE_CLUSTER_AGGREGATE_ROLES: "true"
+      ARGO_ROLLOUTS_CONTROLLER_REPLICAS: "2"
+      ARGO_ROLLOUTS_LOG_LEVEL: info
+      ARGO_ROLLOUTS_LOG_FORMAT: text
+      ARGO_ROLLOUTS_METRICS_ENABLED: "false"
+      ARGO_ROLLOUTS_SERVICEMONITOR_ENABLED: "false"
+      ARGO_ROLLOUTS_DASHBOARD_ENABLED: "true"
+      ARGO_ROLLOUTS_DASHBOARD_READONLY: "false"
+      ARGO_ROLLOUTS_DASHBOARD_REPLICAS: "1"
+      ARGO_ROLLOUTS_HOSTNAME: argo-rollouts
+      DOMAIN: example.com
+      GATEWAY_NAME: cilium-gateway
+      GATEWAY_NAMESPACE: default
+EOF
+```
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `ARGO_ROLLOUTS_NAMESPACE` | `argo-rollouts` | Target namespace |
+| `ARGO_ROLLOUTS_VERSION` | `2.40.9` | Chart version |
+| `ARGO_ROLLOUTS_INSTALL_CRDS` | `true` | Install and upgrade CRDs |
+| `ARGO_ROLLOUTS_KEEP_CRDS` | `true` | Keep CRDs on helm uninstall |
+| `ARGO_ROLLOUTS_CLUSTER_INSTALL` | `true` | Cluster-wide controller (requires cluster RBAC) |
+| `ARGO_ROLLOUTS_CREATE_CLUSTER_AGGREGATE_ROLES` | `true` | Create cluster aggregate roles |
+| `ARGO_ROLLOUTS_CONTROLLER_REPLICAS` | `2` | Number of controller pods |
+| `ARGO_ROLLOUTS_LOG_LEVEL` | `info` | Controller log level |
+| `ARGO_ROLLOUTS_LOG_FORMAT` | `text` | Controller log format (`text` or `json`) |
+| `ARGO_ROLLOUTS_METRICS_ENABLED` | `false` | Expose Prometheus metrics service |
+| `ARGO_ROLLOUTS_SERVICEMONITOR_ENABLED` | `false` | Deploy a Prometheus `ServiceMonitor` |
+| `ARGO_ROLLOUTS_DASHBOARD_ENABLED` | `true` | Deploy the Argo Rollouts dashboard |
+| `ARGO_ROLLOUTS_DASHBOARD_READONLY` | `false` | Read-only dashboard cluster role |
+| `ARGO_ROLLOUTS_DASHBOARD_REPLICAS` | `1` | Number of dashboard pods |
+| `ARGO_ROLLOUTS_HOSTNAME` | `argo-rollouts` | Hostname prefix for the dashboard HTTPRoute |
+| `DOMAIN` | *(required)* | Domain suffix for the dashboard HTTPRoute |
+| `GATEWAY_NAME` | `cilium-gateway` | Gateway resource name |
+| `GATEWAY_NAMESPACE` | `default` | Namespace of the Gateway resource |
+
+The dashboard is exposed via a Gateway API `HTTPRoute` (`httproute.yaml`) instead
+of the chart's built-in ingress, consistent with other apps in this repository.

--- a/cicd/argo-rollouts/httproute.yaml
+++ b/cicd/argo-rollouts/httproute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argo-rollouts-dashboard
+  namespace: ${ARGO_ROLLOUTS_NAMESPACE:-argo-rollouts}
+spec:
+  parentRefs:
+    - name: ${GATEWAY_NAME:-cilium-gateway}
+      namespace: ${GATEWAY_NAMESPACE:-default}
+  hostnames:
+    - "${ARGO_ROLLOUTS_HOSTNAME:-argo-rollouts}.${DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: argo-rollouts-dashboard
+          port: 3100

--- a/cicd/argo-rollouts/kustomization.yaml
+++ b/cicd/argo-rollouts/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml
+  - httproute.yaml

--- a/cicd/argo-rollouts/release.yaml
+++ b/cicd/argo-rollouts/release.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: argo-rollouts
+  namespace: ${ARGO_ROLLOUTS_NAMESPACE:-argo-rollouts}
+spec:
+  interval: 30m
+  timeout: 10m
+  chart:
+    spec:
+      chart: argo-rollouts
+      version: ${ARGO_ROLLOUTS_VERSION:-2.40.9}
+      sourceRef:
+        kind: HelmRepository
+        name: argo
+        namespace: ${ARGO_ROLLOUTS_NAMESPACE:-argo-rollouts}
+      interval: 12h
+  values:
+    installCRDs: ${ARGO_ROLLOUTS_INSTALL_CRDS:-true}
+    keepCRDs: ${ARGO_ROLLOUTS_KEEP_CRDS:-true}
+    clusterInstall: ${ARGO_ROLLOUTS_CLUSTER_INSTALL:-true}
+    createClusterAggregateRoles: ${ARGO_ROLLOUTS_CREATE_CLUSTER_AGGREGATE_ROLES:-true}
+    controller:
+      replicas: ${ARGO_ROLLOUTS_CONTROLLER_REPLICAS:-2}
+      logging:
+        level: ${ARGO_ROLLOUTS_LOG_LEVEL:-info}
+        format: ${ARGO_ROLLOUTS_LOG_FORMAT:-text}
+      metrics:
+        enabled: ${ARGO_ROLLOUTS_METRICS_ENABLED:-false}
+        serviceMonitor:
+          enabled: ${ARGO_ROLLOUTS_SERVICEMONITOR_ENABLED:-false}
+    providerRBAC:
+      enabled: true
+      providers:
+        gatewayAPI: true
+    dashboard:
+      enabled: ${ARGO_ROLLOUTS_DASHBOARD_ENABLED:-true}
+      readonly: ${ARGO_ROLLOUTS_DASHBOARD_READONLY:-false}
+      replicas: ${ARGO_ROLLOUTS_DASHBOARD_REPLICAS:-1}
+      service:
+        type: ClusterIP
+        port: 3100
+        targetPort: 3100
+      ingress:
+        enabled: false

--- a/cicd/argo-rollouts/requirements.yaml
+++ b/cicd/argo-rollouts/requirements.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${ARGO_ROLLOUTS_NAMESPACE:-argo-rollouts}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: argo
+  namespace: ${ARGO_ROLLOUTS_NAMESPACE:-argo-rollouts}
+spec:
+  interval: 1h
+  url: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
## Summary
- Adds `cicd/argo-rollouts/` as a new Flux app sourced from the `argo-helm` Helm repository (`https://argoproj.github.io/argo-helm`, chart `argo-rollouts`), pinned to `2.40.9` by default.
- Enables `installCRDs`, `keepCRDs`, `clusterInstall`, `createClusterAggregateRoles` and `providerRBAC.providers.gatewayAPI` so the controller can drive Gateway API traffic shifting.
- Enables the Argo Rollouts dashboard (chart ingress disabled) and exposes it via a Gateway API `HTTPRoute` (`argo-rollouts-dashboard` service on port `3100`), consistent with other apps in this repo.
- Equivalent of `helm install argo-rollouts argo/argo-rollouts --version 2.40.9 --create-namespace --namespace argo-rollouts --wait`.

## Test plan
- [ ] `kubectl apply` the Flux `Kustomization` from `cicd/argo-rollouts/README.md` against a test cluster with `DOMAIN` and `GATEWAY_NAME`/`GATEWAY_NAMESPACE` set appropriately.
- [ ] Verify the `argo-rollouts` `HelmRelease` reconciles and the `argo-rollouts` + `argo-rollouts-dashboard` pods come up healthy.
- [ ] Verify CRDs (`Rollout`, `AnalysisTemplate`, `Experiment`, etc.) are installed.
- [ ] Verify the `argo-rollouts-dashboard` `HTTPRoute` attaches to the configured gateway and the dashboard is reachable at `argo-rollouts.${DOMAIN}`.
- [ ] Deploy a sample `Rollout` and confirm the controller reconciles it.