### PR TITLE
feat: wire argo-rollouts ui extension into argocd

### DIFF
--- a/cicd/argo-cd/README.md
+++ b/cicd/argo-cd/README.md
@@ -194,6 +194,8 @@ EOF
 | `AVP_TRUST_BUNDLE_KEY` | `trust-bundle.pem` | Key in the trust bundle ConfigMap |
 | `AVP_SSL_CERT_DIR` | `/etc/ssl/custom` | Directory to mount the CA bundle into (sets `SSL_CERT_DIR`) |
 | `ARGO_CD_PASSWORD_MTIME` | `2024-09-16T12:51:06UTC` | Admin password modification time |
+| `ARGO_CD_EXTENSIONS_ENABLED` | `false` | Enable Argo CD UI extensions (spawns the extensions init container on the server) |
+| `ARGO_CD_ROLLOUT_EXTENSION_URL` | `https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar` | Download URL of the [argo-rollouts UI extension](https://github.com/argoproj-labs/rollout-extension) (only used when `ARGO_CD_EXTENSIONS_ENABLED=true`) |
 | `ARGO_CD_SERVER_ADMIN_PASSWORD` | *(from Secret)* | Admin password (bcrypt htpasswd hash) |
 | `VAULT_ROLE_ID` | *(from Secret)* | Vault AppRole Role ID |
 | `VAULT_SECRET_ID` | *(from Secret)* | Vault AppRole Secret ID |

--- a/cicd/argo-cd/release.yaml
+++ b/cicd/argo-cd/release.yaml
@@ -23,6 +23,13 @@ spec:
     server:
       extraArgs:
         - --insecure
+      extensions:
+        enabled: ${ARGO_CD_EXTENSIONS_ENABLED:-false}
+        extensionList:
+          - name: argo-rollouts
+            env:
+              - name: EXTENSION_URL
+                value: ${ARGO_CD_ROLLOUT_EXTENSION_URL:-https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar}
       ingress:
         enabled: ${ARGO_CD_INGRESS_ENABLED:-false}
         annotations:


### PR DESCRIPTION
## Summary
- Adds an opt-in `server.extensions` block to `cicd/argo-cd/release.yaml` so the [argoproj-labs rollout-extension](https://github.com/argoproj-labs/rollout-extension) tarball can be loaded by the Argo CD UI.
- Gated behind two new substitution variables:
  - `ARGO_CD_EXTENSIONS_ENABLED` — default `false`. Flip to `"true"` to spawn the extensions init container on the argocd-server pod.
  - `ARGO_CD_ROLLOUT_EXTENSION_URL` — default `https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar`. Override to bump the extension version.
- No-op for existing deployments that don't set the new variables, so it's safe to roll out without downstream changes.

## Test plan
- [ ] Reconcile the argo-cd Kustomization without setting the new variables and confirm no change to the running argocd-server pods (no extra init container).
- [ ] Set `ARGO_CD_EXTENSIONS_ENABLED: "true"` in the consumer `Kustomization` `postBuild.substitute` map and confirm the `extensions` init container runs and downloads the tarball.
- [ ] Open the Argo CD UI on a `Rollout` resource and verify the rollout extension tab renders.
- [ ] Optionally pair with stuttgart-things/flux#88 (argo-rollouts controller) to exercise the end-to-end flow.