### PR TITLE
docs(kargo): wire admin credentials through a Secret + substituteFrom

### DIFF
--- a/apps/kargo/README.md
+++ b/apps/kargo/README.md
@@ -15,6 +15,60 @@ helm install kargo \
   --wait
 ```
 
+## Requirements
+
+<details><summary>ADD GITREPOSITORY</summary>
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    branch: main
+  url: https://github.com/stuttgart-things/flux.git
+EOF
+```
+
+</details>
+
+<details><summary>CREATE SECRET</summary>
+
+The admin credentials contain `$` characters (bcrypt hashes) that collide with
+Flux's `postBuild.substitute` envsubst-style expansion. Pass them through a
+Kubernetes `Secret` and `substituteFrom` instead of inlining them — Flux reads
+secret values literally, no escaping required.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kargo-secrets
+  namespace: flux-system
+type: Opaque
+stringData:
+  KARGO_ADMIN_PASSWORD_HASH: '<bcrypt-hash>' # pragma: allowlist secret
+  KARGO_ADMIN_TOKEN_SIGNING_KEY: '<random-signing-key>' # pragma: allowlist secret
+EOF
+```
+
+Generate the values:
+
+```bash
+# Password hash (bcrypt, $2a$ variant)
+htpasswd -bnBC 10 "" '<your-password>' | tr -d ':\n' | sed 's/$2y/$2a/'
+
+# Token signing key
+openssl rand -base64 29 | tr -d "=+/" | head -c 32
+```
+
+</details>
+
 ## Main Kargo Deployment
 
 ```bash
@@ -41,8 +95,6 @@ spec:
       KARGO_VERSION: "1.9.6"
       KARGO_HOSTNAME: kargo
       KARGO_DOMAIN: example.sthings-vsphere.example.com
-      KARGO_ADMIN_PASSWORD_HASH: "<bcrypt-hash>"
-      KARGO_ADMIN_TOKEN_SIGNING_KEY: "<random-signing-key>"
       KARGO_ADMIN_TOKEN_TTL: 24h
       KARGO_SERVICE_TYPE: ClusterIP
       KARGO_API_TLS_ENABLED: "false"
@@ -53,18 +105,16 @@ spec:
       INGRESS_CLASS_NAME: nginx
       ISSUER_NAME: cluster-issuer-approle
       ISSUER_KIND: ClusterIssuer
+    substituteFrom:
+      - kind: Secret
+        name: kargo-secrets
 EOF
 ```
 
-## Generating admin credentials
-
-```bash
-# Password hash (bcrypt)
-htpasswd -bnBC 10 "" <your-password> | tr -d ':\n' | sed 's/$2y/$2a/'
-
-# Token signing key
-openssl rand -base64 29 | tr -d "=+/" | head -c 32
-```
+`KARGO_ADMIN_PASSWORD_HASH` and `KARGO_ADMIN_TOKEN_SIGNING_KEY` come from the
+`kargo-secrets` Secret via `substituteFrom` — do **not** inline them under
+`substitute:`, as the `$` characters in the bcrypt hash would be mangled by
+envsubst.
 
 ## Optional: HTTPRoute (Gateway API)
 


### PR DESCRIPTION
## Summary
- Documents the correct way to pass Kargo admin credentials through Flux: create a `kargo-secrets` Kubernetes `Secret` in `flux-system` and reference it via `substituteFrom` on the consumer's Flux `Kustomization`.
- Removes `KARGO_ADMIN_PASSWORD_HASH` / `KARGO_ADMIN_TOKEN_SIGNING_KEY` from the inline `substitute:` example, which was broken: the `$` characters in a bcrypt hash (`$2a$10$...`) collide with Flux's envsubst-style `postBuild.substitute` and get mangled at reconcile time. Values sourced via `substituteFrom` are read literally.
- Adds an `htpasswd` / `openssl` one-liner snippet for generating the hash and the token signing key.
- No code changes — `apps/kargo/release.yaml` already references the two variables, so existing deployments that already use `substituteFrom` keep working unchanged.

## Test plan
- [ ] `kubectl apply` the `kargo-secrets` Secret from the README snippet against a test cluster with a freshly generated bcrypt hash.
- [ ] Reconcile the `kargo` Flux `Kustomization` with `substituteFrom: [{kind: Secret, name: kargo-secrets}]` and confirm the `kargo` `HelmRelease` reconciles cleanly.
- [ ] Exec into a Kargo API pod or inspect the rendered values and confirm the password hash round-trips with the `$` characters intact (no envsubst mangling).
- [ ] Log in to the Kargo UI as `admin` with the password matching the supplied bcrypt hash.