### PR TITLE
feat(argocd): add cilium app-of-apps + ApplicationSet test

### DIFF
--- a/tests/argocd/cilium/README.md
+++ b/tests/argocd/cilium/README.md
@@ -1,0 +1,92 @@
+# Cilium on Argo CD
+
+ArgoCD equivalent of [`infra/cilium`](../../../infra/cilium) (Flux). The Flux
+HelmRelease + Kustomize components are split into three Argo CD `Application`s
+(App-of-Apps) and deployed per cluster via an `ApplicationSet`.
+
+## Layout
+
+```
+tests/argocd/cilium/
+├── apps/                      # App-of-Apps: 3 child Applications (static defaults)
+│   ├── cilium.yaml            #   → Cilium Helm chart (sync-wave -10)
+│   ├── cilium-lb.yaml         #   → CiliumLoadBalancerIPPool + L2 policy (wave 0)
+│   └── cilium-gateway.yaml    #   → Gateway API Gateway (wave 10)
+├── manifests/
+│   ├── lb/                    # Kustomize base for LB/L2 CRs
+│   └── gateway/               # Kustomize base for Gateway
+├── clusters/
+│   └── example/
+│       ├── cluster.yaml       # per-cluster params consumed by ApplicationSet
+│       └── values.yaml        # Cilium Helm values
+├── root-app.yaml              # (Option A) static App-of-Apps root
+└── appset.yaml                # (Option B) 3 ApplicationSets, one per component
+```
+
+## Mapping from Flux
+
+| Flux (`infra/cilium`)                 | ArgoCD (`tests/argocd/cilium`)                        |
+|---------------------------------------|-------------------------------------------------------|
+| `components/install/requirements.yaml`| Namespace auto-created via `CreateNamespace=true`; `HelmRepository` replaced by Argo CD's built-in Helm source |
+| `components/install/release.yaml`     | `apps/cilium.yaml` — Helm `Application`               |
+| `components/lb/cilium-config.yaml`    | `manifests/lb/` + `apps/cilium-lb.yaml` (wave 0)      |
+| `components/gateway/gateway.yaml`     | `manifests/gateway/` + `apps/cilium-gateway.yaml` (wave 10) |
+| `dependsOn`                           | `argocd.argoproj.io/sync-wave` annotations            |
+| `${VAR:-default}` (`postBuild.substitute`) | Helm `valuesObject` / Kustomize patches / ApplicationSet `goTemplate` |
+
+Ordering is enforced with sync-waves so the Cilium Helm release (and its CRDs)
+reconciles before the LB/Gateway Applications try to apply Cilium-owned CRs.
+
+## Deployment — Option A: static App-of-Apps
+
+Single cluster, no templating:
+
+```bash
+kubectl apply -f root-app.yaml
+```
+
+`root-app.yaml` points at `apps/` and pulls in the three child Applications with
+their default values. Edit values directly in `apps/cilium.yaml` or fork and
+override.
+
+## Deployment — Option B: ApplicationSet (multi-cluster)
+
+1. Add a cluster directory under `clusters/` with a `cluster.yaml` describing
+   the target and a `values.yaml` with Cilium Helm overrides. See
+   `clusters/example/` for the schema.
+2. Apply the ApplicationSets:
+
+   ```bash
+   kubectl apply -f appset.yaml
+   ```
+
+Each ApplicationSet uses a `git` files generator to discover every
+`clusters/*/cluster.yaml`, then templates the matching Application per cluster.
+
+### `cluster.yaml` schema
+
+```yaml
+cluster:
+  name: <short name used in Application names>
+  server: <Kubernetes API URL or in-cluster URL>
+cilium:
+  chartVersion: <Helm chart version>
+  namespace: <install namespace, typically kube-system>
+lb:
+  ipStart: <first LB IP>
+  ipStop:  <last LB IP>
+gateway:
+  namespace: <namespace for the Gateway resource>
+  domain:    <DNS zone; becomes *.DOMAIN>
+  tlsSecret: <Secret holding the wildcard cert>
+```
+
+## Prerequisites
+
+- Argo CD installed in the `argocd` namespace.
+- For Option B: the Argo CD instance must be able to reach the target clusters
+  (registered as cluster secrets) and read this git repo.
+- For the Gateway Application: a wildcard TLS secret matching `gateway.domain`
+  must exist in `gateway.namespace` before the Gateway can bind its listener.
+- Gateway API CRDs (`gateway.networking.k8s.io/v1`) installed on the target
+  cluster. The Cilium chart does not ship them.

--- a/tests/argocd/cilium/apps/cilium-gateway.yaml
+++ b/tests/argocd/cilium/apps/cilium-gateway.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium-gateway
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/cilium/manifests/gateway
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/tests/argocd/cilium/apps/cilium-lb.yaml
+++ b/tests/argocd/cilium/apps/cilium-lb.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium-lb
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/cilium/manifests/lb
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/tests/argocd/cilium/apps/cilium.yaml
+++ b/tests/argocd/cilium/apps/cilium.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  project: default
+  source:
+    repoURL: https://helm.cilium.io
+    chart: cilium
+    targetRevision: 1.18.5
+    helm:
+      releaseName: cilium
+      valuesObject:
+        kubeProxyReplacement: true
+        k8sServiceHost: ""
+        k8sServicePort: 6443
+        operator:
+          replicas: 1
+        gatewayAPI:
+          enabled: true
+        l2announcements:
+          enabled: true
+        externalIPs:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/tests/argocd/cilium/apps/kustomization.yaml
+++ b/tests/argocd/cilium/apps/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cilium.yaml
+  - cilium-lb.yaml
+  - cilium-gateway.yaml

--- a/tests/argocd/cilium/appset.yaml
+++ b/tests/argocd/cilium/appset.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cilium-install
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/cilium/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'cilium-install-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "-10"
+      labels:
+        app.kubernetes.io/part-of: cilium
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://helm.cilium.io
+          chart: cilium
+          targetRevision: '{{ .cilium.chartVersion }}'
+          helm:
+            releaseName: cilium
+            valueFiles:
+              - $values/tests/argocd/cilium/clusters/{{ .cluster.name }}/values.yaml
+        - repoURL: https://github.com/stuttgart-things/flux.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .cilium.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cilium-lb
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/cilium/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'cilium-lb-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "0"
+      labels:
+        app.kubernetes.io/part-of: cilium
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        targetRevision: HEAD
+        path: tests/argocd/cilium/manifests/lb
+        kustomize:
+          patches:
+            - target:
+                kind: CiliumLoadBalancerIPPool
+                name: default-pool
+              patch: |
+                - op: replace
+                  path: /spec/blocks/0/start
+                  value: '{{ .lb.ipStart }}'
+                - op: replace
+                  path: /spec/blocks/0/stop
+                  value: '{{ .lb.ipStop }}'
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .cilium.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cilium-gateway
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/cilium/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'cilium-gateway-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "10"
+      labels:
+        app.kubernetes.io/part-of: cilium
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        targetRevision: HEAD
+        path: tests/argocd/cilium/manifests/gateway
+        kustomize:
+          patches:
+            - target:
+                kind: Gateway
+                name: cilium-gateway
+              patch: |
+                - op: replace
+                  path: /spec/listeners/0/hostname
+                  value: '*.{{ .gateway.domain }}'
+                - op: replace
+                  path: /spec/listeners/0/tls/certificateRefs/0/name
+                  value: '{{ .gateway.tlsSecret }}'
+                - op: replace
+                  path: /spec/listeners/1/hostname
+                  value: '*.{{ .gateway.domain }}'
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .gateway.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/tests/argocd/cilium/clusters/example/cluster.yaml
+++ b/tests/argocd/cilium/clusters/example/cluster.yaml
@@ -1,0 +1,14 @@
+---
+cluster:
+  name: example
+  server: https://kubernetes.default.svc
+cilium:
+  chartVersion: 1.18.5
+  namespace: kube-system
+lb:
+  ipStart: 192.168.1.240
+  ipStop: 192.168.1.250
+gateway:
+  namespace: default
+  domain: example.com
+  tlsSecret: cilium-gateway-tls

--- a/tests/argocd/cilium/clusters/example/values.yaml
+++ b/tests/argocd/cilium/clusters/example/values.yaml
@@ -1,0 +1,12 @@
+---
+kubeProxyReplacement: true
+k8sServiceHost: ""
+k8sServicePort: 6443
+operator:
+  replicas: 1
+gatewayAPI:
+  enabled: true
+l2announcements:
+  enabled: true
+externalIPs:
+  enabled: true

--- a/tests/argocd/cilium/manifests/gateway/gateway.yaml
+++ b/tests/argocd/cilium/manifests/gateway/gateway.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cilium-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      hostname: "*.example.com"
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: cilium-gateway-tls
+    - name: http
+      hostname: "*.example.com"
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/tests/argocd/cilium/manifests/gateway/kustomization.yaml
+++ b/tests/argocd/cilium/manifests/gateway/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gateway.yaml

--- a/tests/argocd/cilium/manifests/lb/cilium-config.yaml
+++ b/tests/argocd/cilium/manifests/lb/cilium-config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: default-pool
+spec:
+  blocks:
+    - start: 192.168.1.240
+      stop: 192.168.1.250
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: default-l2-announcement-policy
+  namespace: kube-system
+spec:
+  externalIPs: true
+  loadBalancerIPs: true

--- a/tests/argocd/cilium/manifests/lb/kustomization.yaml
+++ b/tests/argocd/cilium/manifests/lb/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cilium-config.yaml

--- a/tests/argocd/cilium/root-app.yaml
+++ b/tests/argocd/cilium/root-app.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium-root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/cilium/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Mirrors `infra/cilium` (Flux) as an Argo CD deployment under `tests/argocd/cilium/`:

- **App-of-Apps** (`apps/`): three `Application`s — `cilium` (Helm, sync-wave `-10`), `cilium-lb` (Kustomize, wave `0`), `cilium-gateway` (Kustomize, wave `10`). Sync-waves replace Flux `dependsOn`.
- **Bases** (`manifests/lb`, `manifests/gateway`): Kustomize sources for the Cilium LB/L2 CRs and the Gateway API `Gateway`.
- **Per-cluster fan-out** (`appset.yaml`): three `ApplicationSet`s using a git-files generator over `clusters/*/cluster.yaml` with `goTemplate` to inject chart version, LB IP range, Gateway domain, TLS secret, and Helm `valueFiles`.
- **Single-cluster path** (`root-app.yaml`): static App-of-Apps root if you don't need multi-cluster.
- `clusters/example/` holds an example `cluster.yaml` + Cilium `values.yaml`.
- README documents the Flux → Argo CD mapping, both deployment options, the `cluster.yaml` schema, and prereqs (Gateway API CRDs, wildcard TLS secret).

Flux `${VAR:-default}` `postBuild.substitute` is replaced by Helm `valueFiles`/`valuesObject`, Kustomize `patches`, and ApplicationSet go-templates.

## Test plan

- [ ] `kubectl apply -f tests/argocd/cilium/root-app.yaml` on a cluster with Argo CD + Gateway API CRDs; confirm the three child Applications appear and sync in wave order.
- [ ] `kubectl apply -f tests/argocd/cilium/appset.yaml` and confirm three `Application`s per entry in `clusters/*/cluster.yaml` are generated with templated values.
- [ ] Verify `CiliumLoadBalancerIPPool` picks up `lb.ipStart`/`lb.ipStop` from the patched overlay.
- [ ] Verify the `Gateway` listeners use `*.{gateway.domain}` and reference `gateway.tlsSecret`.
- [ ] Delete the ApplicationSet entry for a cluster; confirm its Applications are pruned.

https://claude.ai/code/session_01F48RL9fSerXwvQD9dt1DCt