### PR TITLE
feat(argocd): mirror cert-manager, openebs, nfs-csi under tests/argocd

### DIFF
--- a/tests/argocd/cert-manager/README.md
+++ b/tests/argocd/cert-manager/README.md
@@ -1,0 +1,95 @@
+# cert-manager on Argo CD
+
+ArgoCD equivalent of [`infra/cert-manager`](../../../infra/cert-manager) (Flux).
+Splits the install and the selfsigned bootstrap chain into two `Application`s
+(App-of-Apps), with a per-cluster `ApplicationSet` for fan-out.
+
+> Note: the Vault `ClusterIssuer` from the Flux `post-release.yaml` is not
+> mirrored here — it's environment-specific (Vault address, AppRole, PKI
+> path). See [Adding a Vault issuer](#adding-a-vault-issuer) for the pattern.
+
+## Layout
+
+```
+tests/argocd/cert-manager/
+├── apps/                          # App-of-Apps (static defaults)
+│   ├── cert-manager.yaml          #   → Helm chart (sync-wave -10)
+│   └── cert-manager-bootstrap.yaml#   → selfsigned + cluster-CA + wildcard cert (wave 0)
+├── manifests/
+│   └── bootstrap/                 # Kustomize base for the bootstrap CA chain
+├── clusters/
+│   └── example/
+│       ├── cluster.yaml           # per-cluster params for the ApplicationSet
+│       └── values.yaml            # cert-manager Helm values
+├── root-app.yaml                  # (Option A) static App-of-Apps root
+└── appset.yaml                    # (Option B) ApplicationSets, per-cluster fan-out
+```
+
+## Mapping from Flux
+
+| Flux                                      | ArgoCD                                                |
+|-------------------------------------------|-------------------------------------------------------|
+| `requirements.yaml` (`Namespace` + `HelmRepository`) | `CreateNamespace=true` + Argo CD's built-in Helm source |
+| `release.yaml` (HelmRelease)              | `apps/cert-manager.yaml`                              |
+| `post-release.yaml` (Vault issuer)        | Not mirrored (see below)                              |
+| `components/selfsigned/`                  | `apps/cert-manager-bootstrap.yaml` + `manifests/bootstrap/` |
+| `dependsOn`                               | `argocd.argoproj.io/sync-wave`                        |
+| `${VAR:-default}`                         | Helm `valuesObject` / Kustomize `patches` / ApplicationSet `goTemplate` |
+
+The bootstrap Application waits one wave behind the Helm install so the
+cert-manager webhook is available before any `Certificate`/`ClusterIssuer`
+resources are submitted.
+
+## Deployment — Option A: static App-of-Apps
+
+```bash
+kubectl apply -f root-app.yaml
+```
+
+Pulls in both child Applications with the defaults baked into `apps/`. Edit
+those files (or fork) to change values.
+
+## Deployment — Option B: ApplicationSet (multi-cluster)
+
+1. Add a directory under `clusters/` with `cluster.yaml` + `values.yaml`. Use
+   `clusters/example/` as a template.
+2. Apply:
+
+   ```bash
+   kubectl apply -f appset.yaml
+   ```
+
+Each ApplicationSet uses a git-files generator to discover every
+`clusters/*/cluster.yaml` and templates one Application per cluster.
+
+### `cluster.yaml` schema
+
+```yaml
+cluster:
+  name: <short name used in Application names>
+  server: <Kubernetes API URL or in-cluster URL>
+certManager:
+  chartVersion: <Helm chart version, e.g. v1.19.2>
+  namespace: <install namespace>
+bootstrap:
+  caName:             <name of bootstrap CA Certificate + ClusterIssuer>
+  caSecret:           <Secret holding the CA keypair>
+  wildcardCertName:   <name of wildcard Certificate>
+  wildcardSecret:     <Secret name for the wildcard cert>
+  wildcardNamespace:  <namespace for the wildcard cert (typically gateway ns)>
+  domain:             <DNS zone; becomes *.DOMAIN>
+```
+
+## Adding a Vault issuer
+
+To replicate `infra/cert-manager/post-release.yaml`, add a third Application
+that points at a Kustomize base containing a `ClusterIssuer` with
+`spec.vault`, plus a `Secret` for the AppRole `secret_id`. Patch values
+(`vault.path`, `vault.server`, AppRole IDs) via ApplicationSet `kustomize.patches`
+the same way `cert-manager-bootstrap` does.
+
+## Prerequisites
+
+- Argo CD installed in the `argocd` namespace.
+- For Option B: target clusters registered as Argo CD cluster secrets, and Argo
+  CD must be able to read this git repo.

--- a/tests/argocd/cert-manager/apps/cert-manager-bootstrap.yaml
+++ b/tests/argocd/cert-manager/apps/cert-manager-bootstrap.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-bootstrap
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/cert-manager/manifests/bootstrap
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/tests/argocd/cert-manager/apps/cert-manager.yaml
+++ b/tests/argocd/cert-manager/apps/cert-manager.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: v1.19.2
+    helm:
+      releaseName: cert-manager
+      valuesObject:
+        crds:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/tests/argocd/cert-manager/apps/kustomization.yaml
+++ b/tests/argocd/cert-manager/apps/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager.yaml
+  - cert-manager-bootstrap.yaml

--- a/tests/argocd/cert-manager/appset.yaml
+++ b/tests/argocd/cert-manager/appset.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cert-manager-install
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/cert-manager/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'cert-manager-install-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "-10"
+      labels:
+        app.kubernetes.io/part-of: cert-manager
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://charts.jetstack.io
+          chart: cert-manager
+          targetRevision: '{{ .certManager.chartVersion }}'
+          helm:
+            releaseName: cert-manager
+            valueFiles:
+              - $values/tests/argocd/cert-manager/clusters/{{ .cluster.name }}/values.yaml
+        - repoURL: https://github.com/stuttgart-things/flux.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .certManager.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cert-manager-bootstrap
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/cert-manager/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'cert-manager-bootstrap-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "0"
+      labels:
+        app.kubernetes.io/part-of: cert-manager
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        targetRevision: HEAD
+        path: tests/argocd/cert-manager/manifests/bootstrap
+        kustomize:
+          patches:
+            - target:
+                kind: Certificate
+                name: cluster-ca
+              patch: |
+                - op: replace
+                  path: /metadata/name
+                  value: '{{ .bootstrap.caName }}'
+                - op: replace
+                  path: /metadata/namespace
+                  value: '{{ .certManager.namespace }}'
+                - op: replace
+                  path: /spec/commonName
+                  value: '{{ .bootstrap.caName }}'
+                - op: replace
+                  path: /spec/secretName
+                  value: '{{ .bootstrap.caSecret }}'
+            - target:
+                kind: ClusterIssuer
+                name: cluster-ca
+              patch: |
+                - op: replace
+                  path: /spec/ca/secretName
+                  value: '{{ .bootstrap.caSecret }}'
+            - target:
+                kind: Certificate
+                name: wildcard-tls
+              patch: |
+                - op: replace
+                  path: /metadata/name
+                  value: '{{ .bootstrap.wildcardCertName }}'
+                - op: replace
+                  path: /metadata/namespace
+                  value: '{{ .bootstrap.wildcardNamespace }}'
+                - op: replace
+                  path: /spec/secretName
+                  value: '{{ .bootstrap.wildcardSecret }}'
+                - op: replace
+                  path: /spec/commonName
+                  value: '*.{{ .bootstrap.domain }}'
+                - op: replace
+                  path: /spec/dnsNames/0
+                  value: '*.{{ .bootstrap.domain }}'
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .certManager.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/tests/argocd/cert-manager/clusters/example/cluster.yaml
+++ b/tests/argocd/cert-manager/clusters/example/cluster.yaml
@@ -1,0 +1,14 @@
+---
+cluster:
+  name: example
+  server: https://kubernetes.default.svc
+certManager:
+  chartVersion: v1.19.2
+  namespace: cert-manager
+bootstrap:
+  caName: cluster-ca
+  caSecret: cluster-ca-secret
+  wildcardCertName: wildcard-tls
+  wildcardSecret: wildcard-tls
+  wildcardNamespace: default
+  domain: example.com

--- a/tests/argocd/cert-manager/clusters/example/values.yaml
+++ b/tests/argocd/cert-manager/clusters/example/values.yaml
@@ -1,0 +1,3 @@
+---
+crds:
+  enabled: true

--- a/tests/argocd/cert-manager/manifests/bootstrap/kustomization.yaml
+++ b/tests/argocd/cert-manager/manifests/bootstrap/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - selfsigned.yaml

--- a/tests/argocd/cert-manager/manifests/bootstrap/selfsigned.yaml
+++ b/tests/argocd/cert-manager/manifests/bootstrap/selfsigned.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: cluster-ca
+  secretName: cluster-ca-secret
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cluster-ca
+spec:
+  ca:
+    secretName: cluster-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-tls
+  namespace: default
+spec:
+  secretName: wildcard-tls
+  issuerRef:
+    name: cluster-ca
+    kind: ClusterIssuer
+  commonName: "*.example.com"
+  dnsNames:
+    - "*.example.com"
+  duration: 2160h
+  renewBefore: 360h

--- a/tests/argocd/cert-manager/root-app.yaml
+++ b/tests/argocd/cert-manager/root-app.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/cert-manager/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tests/argocd/nfs-csi/README.md
+++ b/tests/argocd/nfs-csi/README.md
@@ -1,0 +1,79 @@
+# nfs-csi on Argo CD
+
+ArgoCD equivalent of [`infra/nfs-csi`](../../../infra/nfs-csi) (Flux). Splits
+the Helm install of `csi-driver-nfs` and the `StorageClass` definitions into two
+`Application`s (App-of-Apps), with a per-cluster `ApplicationSet` for fan-out.
+
+## Layout
+
+```
+tests/argocd/nfs-csi/
+├── apps/
+│   ├── nfs-csi.yaml               # Helm chart (sync-wave -10)
+│   └── nfs-csi-storageclasses.yaml# StorageClasses (wave 10)
+├── manifests/
+│   └── storageclasses/            # nfs3-csi + nfs4-csi StorageClasses
+├── clusters/
+│   └── example/
+│       ├── cluster.yaml           # per-cluster params (NFS server / share)
+│       └── values.yaml            # csi-driver-nfs Helm values
+├── root-app.yaml                  # (Option A) static App-of-Apps root
+└── appset.yaml                    # (Option B) ApplicationSets, per-cluster fan-out
+```
+
+## Mapping from Flux
+
+| Flux                                          | ArgoCD                                                |
+|-----------------------------------------------|-------------------------------------------------------|
+| `requirements.yaml` (`HelmRepository`s)       | Argo CD's built-in Helm source (chart URL inline)     |
+| `release.yaml` (HelmRelease, `csi-driver-nfs`)| `apps/nfs-csi.yaml`                                   |
+| `post-release.yaml` (sthings-cluster `scs`)   | `apps/nfs-csi-storageclasses.yaml` + `manifests/storageclasses/` (plain `StorageClass`) |
+| `dependsOn`                                   | `argocd.argoproj.io/sync-wave`                        |
+| `${NFS_SERVER_FQDN}`, `${NFS_SHARE_PATH}`, `${CLUSTER_NAME}` | ApplicationSet `kustomize.patches` driven by `cluster.yaml` |
+
+The StorageClasses are written directly here (instead of going through the
+`sthings-cluster` Helm chart) — they're plain k8s objects, easier to read and
+patch in tests.
+
+## Deployment — Option A: static App-of-Apps
+
+```bash
+kubectl apply -f root-app.yaml
+```
+
+Applies both child Applications using the placeholder NFS server in
+`manifests/storageclasses/` (`nfs.example.com`, `/exports`). For real use go
+with Option B.
+
+## Deployment — Option B: ApplicationSet (multi-cluster)
+
+1. Add a directory under `clusters/` with `cluster.yaml` + `values.yaml`. The
+   ApplicationSet will substitute `nfs.server`, `nfs.share`, and `nfs.subDir`
+   into the StorageClass parameters per cluster.
+2. Apply:
+
+   ```bash
+   kubectl apply -f appset.yaml
+   ```
+
+### `cluster.yaml` schema
+
+```yaml
+cluster:
+  name: <short name used in Application names>
+  server: <Kubernetes API URL or in-cluster URL>
+nfsCsi:
+  chartVersion: <Helm chart version, e.g. v4.13.1>
+  namespace: <install namespace, typically kube-system>
+nfs:
+  server:  <NFS server FQDN or IP>
+  share:   <exported path on the server>
+  subDir:  <sub-directory used by the nfs3-csi StorageClass; usually $CLUSTER_NAME>
+```
+
+## Prerequisites
+
+- Argo CD installed in the `argocd` namespace.
+- The target nodes must have the `nfs-common` (or distro equivalent) package
+  so they can mount NFS volumes — handle outside Argo CD.
+- The NFS server must export `nfs.share` and allow the cluster nodes' IPs.

--- a/tests/argocd/nfs-csi/apps/kustomization.yaml
+++ b/tests/argocd/nfs-csi/apps/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfs-csi.yaml
+  - nfs-csi-storageclasses.yaml

--- a/tests/argocd/nfs-csi/apps/nfs-csi-storageclasses.yaml
+++ b/tests/argocd/nfs-csi/apps/nfs-csi-storageclasses.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs-csi-storageclasses
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/nfs-csi/manifests/storageclasses
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m

--- a/tests/argocd/nfs-csi/apps/nfs-csi.yaml
+++ b/tests/argocd/nfs-csi/apps/nfs-csi.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs-csi
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  project: default
+  source:
+    repoURL: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+    chart: csi-driver-nfs
+    targetRevision: v4.13.1
+    helm:
+      releaseName: nfs-csi
+      valuesObject:
+        serviceAccount:
+          create: true
+          controller: csi-nfs-controller-sa
+        rbac:
+          create: true
+          name: nfs
+        driver:
+          name: nfs.csi.k8s.io
+          mountPermissions: 0
+        feature:
+          enableFSGroupPolicy: true
+          enableInlineVolume: false
+        kubeletDir: /var/lib/kubelet
+        externalSnapshotter:
+          enabled: true
+          customResourceDefinitions:
+            enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/tests/argocd/nfs-csi/appset.yaml
+++ b/tests/argocd/nfs-csi/appset.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: nfs-csi-install
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/nfs-csi/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'nfs-csi-install-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "-10"
+      labels:
+        app.kubernetes.io/part-of: nfs-csi
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+          chart: csi-driver-nfs
+          targetRevision: '{{ .nfsCsi.chartVersion }}'
+          helm:
+            releaseName: nfs-csi
+            valueFiles:
+              - $values/tests/argocd/nfs-csi/clusters/{{ .cluster.name }}/values.yaml
+        - repoURL: https://github.com/stuttgart-things/flux.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .nfsCsi.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: nfs-csi-storageclasses
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/nfs-csi/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'nfs-csi-storageclasses-{{ .cluster.name }}'
+      annotations:
+        argocd.argoproj.io/sync-wave: "10"
+      labels:
+        app.kubernetes.io/part-of: nfs-csi
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        targetRevision: HEAD
+        path: tests/argocd/nfs-csi/manifests/storageclasses
+        kustomize:
+          patches:
+            - target:
+                kind: StorageClass
+                name: nfs3-csi
+              patch: |
+                - op: replace
+                  path: /parameters/server
+                  value: '{{ .nfs.server }}'
+                - op: replace
+                  path: /parameters/share
+                  value: '{{ .nfs.share }}'
+                - op: replace
+                  path: /parameters/subDir
+                  value: '{{ .nfs.subDir }}'
+            - target:
+                kind: StorageClass
+                name: nfs4-csi
+              patch: |
+                - op: replace
+                  path: /parameters/server
+                  value: '{{ .nfs.server }}'
+                - op: replace
+                  path: /parameters/share
+                  value: '{{ .nfs.share }}'
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .nfsCsi.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/tests/argocd/nfs-csi/clusters/example/cluster.yaml
+++ b/tests/argocd/nfs-csi/clusters/example/cluster.yaml
@@ -1,0 +1,11 @@
+---
+cluster:
+  name: example
+  server: https://kubernetes.default.svc
+nfsCsi:
+  chartVersion: v4.13.1
+  namespace: kube-system
+nfs:
+  server: nfs.example.com
+  share: /exports
+  subDir: DOWNSTREAM

--- a/tests/argocd/nfs-csi/clusters/example/values.yaml
+++ b/tests/argocd/nfs-csi/clusters/example/values.yaml
@@ -1,0 +1,18 @@
+---
+serviceAccount:
+  create: true
+  controller: csi-nfs-controller-sa
+rbac:
+  create: true
+  name: nfs
+driver:
+  name: nfs.csi.k8s.io
+  mountPermissions: 0
+feature:
+  enableFSGroupPolicy: true
+  enableInlineVolume: false
+kubeletDir: /var/lib/kubelet
+externalSnapshotter:
+  enabled: true
+  customResourceDefinitions:
+    enabled: false

--- a/tests/argocd/nfs-csi/manifests/storageclasses/kustomization.yaml
+++ b/tests/argocd/nfs-csi/manifests/storageclasses/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfs3.yaml
+  - nfs4.yaml

--- a/tests/argocd/nfs-csi/manifests/storageclasses/nfs3.yaml
+++ b/tests/argocd/nfs-csi/manifests/storageclasses/nfs3.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs3-csi
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: nfs.example.com
+  share: /exports
+  subDir: DOWNSTREAM
+  mountPermissions: "0"
+  onDelete: archive
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+mountOptions:
+  - nfsvers=3
+  - rsize=1048576
+  - wsize=1048576
+  - tcp
+  - hard
+  - nolock

--- a/tests/argocd/nfs-csi/manifests/storageclasses/nfs4.yaml
+++ b/tests/argocd/nfs-csi/manifests/storageclasses/nfs4.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs4-csi
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: nfs.example.com
+  share: /exports
+  mountPermissions: "0777"
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+mountOptions:
+  - nfsvers=4.1

--- a/tests/argocd/nfs-csi/root-app.yaml
+++ b/tests/argocd/nfs-csi/root-app.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: nfs-csi-root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/nfs-csi/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tests/argocd/openebs/README.md
+++ b/tests/argocd/openebs/README.md
@@ -1,0 +1,84 @@
+# OpenEBS on Argo CD
+
+ArgoCD equivalent of [`infra/openebs`](../../../infra/openebs) (Flux). Single
+`Application` that installs the OpenEBS umbrella Helm chart, plus an
+`ApplicationSet` for per-cluster fan-out.
+
+## Layout
+
+```
+tests/argocd/openebs/
+├── apps/
+│   └── openebs.yaml               # Helm Application (umbrella chart)
+├── clusters/
+│   └── example/
+│       ├── cluster.yaml           # per-cluster params for the ApplicationSet
+│       └── values.yaml            # OpenEBS Helm values
+├── root-app.yaml                  # (Option A) static App-of-Apps root
+└── appset.yaml                    # (Option B) ApplicationSet, per-cluster fan-out
+```
+
+## Mapping from Flux
+
+| Flux                                         | ArgoCD                                                |
+|----------------------------------------------|-------------------------------------------------------|
+| `requirements.yaml` (`Namespace` + `HelmRepository`) | `CreateNamespace=true` + Argo CD's built-in Helm source |
+| `release.yaml` (HelmRelease)                 | `apps/openebs.yaml`                                   |
+| `${VAR:-default}`                            | Helm `valuesObject` / `valueFiles`                    |
+
+## Engine toggles
+
+The defaults match the Flux release: every optional engine (`local.lvm`,
+`local.zfs`, `replicated.mayastor`) is **off**. Only the local-pv engines
+shipped by default are enabled. To opt into another engine, edit `values.yaml`
+(or your cluster's overlay) — for example:
+
+```yaml
+engines:
+  replicated:
+    mayastor:
+      enabled: true
+mayastor:
+  csi:
+    node:
+      initContainers:
+        enabled: true
+```
+
+Mayastor additionally needs hugepages and the NVMe-TCP kernel module on the
+node — handle that outside Argo CD.
+
+## Deployment — Option A: static App-of-Apps
+
+```bash
+kubectl apply -f root-app.yaml
+```
+
+Applies the single `openebs` Application with the defaults from `apps/openebs.yaml`.
+
+## Deployment — Option B: ApplicationSet (multi-cluster)
+
+1. Add a directory under `clusters/` with `cluster.yaml` + `values.yaml`. See
+   `clusters/example/`.
+2. Apply:
+
+   ```bash
+   kubectl apply -f appset.yaml
+   ```
+
+### `cluster.yaml` schema
+
+```yaml
+cluster:
+  name: <short name used in Application names>
+  server: <Kubernetes API URL or in-cluster URL>
+openebs:
+  chartVersion: <Helm chart version, e.g. 4.2.0>
+  namespace: <install namespace, typically openebs>
+```
+
+## Prerequisites
+
+- Argo CD installed in the `argocd` namespace.
+- A default StorageClass is intentionally NOT marked default by this chart —
+  set one explicitly if needed.

--- a/tests/argocd/openebs/apps/kustomization.yaml
+++ b/tests/argocd/openebs/apps/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - openebs.yaml

--- a/tests/argocd/openebs/apps/openebs.yaml
+++ b/tests/argocd/openebs/apps/openebs.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openebs
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://openebs.github.io/openebs
+    chart: openebs
+    targetRevision: 4.2.0
+    helm:
+      releaseName: openebs
+      valuesObject:
+        openebs-crds:
+          csi:
+            volumeSnapshots:
+              enabled: false
+        mayastor:
+          csi:
+            node:
+              initContainers:
+                enabled: false
+        engines:
+          local:
+            lvm:
+              enabled: false
+            zfs:
+              enabled: false
+          replicated:
+            mayastor:
+              enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: openebs
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/tests/argocd/openebs/appset.yaml
+++ b/tests/argocd/openebs/appset.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: openebs
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions:
+    - missingkey=error
+  generators:
+    - git:
+        repoURL: https://github.com/stuttgart-things/flux.git
+        revision: HEAD
+        files:
+          - path: tests/argocd/openebs/clusters/*/cluster.yaml
+  template:
+    metadata:
+      name: 'openebs-{{ .cluster.name }}'
+      labels:
+        app.kubernetes.io/part-of: openebs
+        cluster: '{{ .cluster.name }}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://openebs.github.io/openebs
+          chart: openebs
+          targetRevision: '{{ .openebs.chartVersion }}'
+          helm:
+            releaseName: openebs
+            valueFiles:
+              - $values/tests/argocd/openebs/clusters/{{ .cluster.name }}/values.yaml
+        - repoURL: https://github.com/stuttgart-things/flux.git
+          targetRevision: HEAD
+          ref: values
+      destination:
+        server: '{{ .cluster.server }}'
+        namespace: '{{ .openebs.namespace }}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/tests/argocd/openebs/clusters/example/cluster.yaml
+++ b/tests/argocd/openebs/clusters/example/cluster.yaml
@@ -1,0 +1,7 @@
+---
+cluster:
+  name: example
+  server: https://kubernetes.default.svc
+openebs:
+  chartVersion: 4.2.0
+  namespace: openebs

--- a/tests/argocd/openebs/clusters/example/values.yaml
+++ b/tests/argocd/openebs/clusters/example/values.yaml
@@ -1,0 +1,19 @@
+---
+openebs-crds:
+  csi:
+    volumeSnapshots:
+      enabled: false
+mayastor:
+  csi:
+    node:
+      initContainers:
+        enabled: false
+engines:
+  local:
+    lvm:
+      enabled: false
+    zfs:
+      enabled: false
+  replicated:
+    mayastor:
+      enabled: false

--- a/tests/argocd/openebs/root-app.yaml
+++ b/tests/argocd/openebs/root-app.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openebs-root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/stuttgart-things/flux.git
+    targetRevision: HEAD
+    path: tests/argocd/openebs/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Mirrors three more Flux infra components under `tests/argocd/`, following the pattern established by `tests/argocd/cilium/` (App-of-Apps + per-cluster ApplicationSet):

- **`tests/argocd/cert-manager/`** — 2 child `Application`s: Helm install (sync-wave `-10`) + selfsigned `ClusterIssuer` / bootstrap CA / wildcard `Certificate` (wave `0`). The Vault `ClusterIssuer` from `infra/cert-manager/post-release.yaml` is intentionally skipped (env-specific: Vault address, AppRole, PKI path); the README documents the pattern to add it back.
- **`tests/argocd/openebs/`** — 1 `Application` for the umbrella Helm chart. Matches Flux defaults (all optional engines — local-LVM, local-ZFS, Mayastor — disabled).
- **`tests/argocd/nfs-csi/`** — 2 child `Application`s: `csi-driver-nfs` Helm install (wave `-10`) + `nfs3-csi` / `nfs4-csi` `StorageClass`es (wave `10`). StorageClasses written as plain manifests rather than via the `sthings-cluster` Helm chart for readability.

Each tree ships `apps/` (App-of-Apps), `manifests/` (where relevant), `clusters/example/`, `root-app.yaml` (single-cluster), `appset.yaml` (per-cluster fan-out via git-files generator + go-templated Kustomize patches / Helm valueFiles), and a README with a Flux→ArgoCD mapping table and `cluster.yaml` schema.

Flux `${VAR:-default}` `postBuild.substitute` maps to Helm `valueFiles`/`valuesObject`, Kustomize `patches`, and ApplicationSet `goTemplate`. Flux `dependsOn` is replaced by `argocd.argoproj.io/sync-wave` annotations.

## Test plan

- [ ] `kubectl apply -f tests/argocd/cert-manager/root-app.yaml` on a cluster with Argo CD installed; confirm cert-manager pods come up before the `ClusterIssuer` / `Certificate` resources sync.
- [ ] `kubectl apply -f tests/argocd/openebs/root-app.yaml`; confirm the default local-pv provisioner pods come up and no Mayastor / LVM / ZFS components are deployed.
- [ ] `kubectl apply -f tests/argocd/nfs-csi/root-app.yaml`; confirm the driver DaemonSet runs, then patch the StorageClass `server`/`share` and verify a PVC can bind.
- [ ] For each, apply `appset.yaml`, add a second entry under `clusters/`, and confirm `Application`s are generated per cluster with templated values (LB IPs / NFS server / cert domain).
- [ ] Delete a `clusters/<name>/cluster.yaml` and confirm the corresponding generated `Application`s are pruned.

https://claude.ai/code/session_01F48RL9fSerXwvQD9dt1DCt