### PR TITLE
feat(argocd): bump AVP image to include kustomize

### DIFF
--- a/cicd/argo-cd/release.yaml
+++ b/cicd/argo-cd/release.yaml
@@ -98,7 +98,7 @@ spec:
       extraContainers:
         - name: argocd-vault-plugin
           command: [/var/run/argocd/argocd-cmp-server]
-          image: ${IMAGE_AVP:-ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.32.3-3.17.2}
+          image: ${IMAGE_AVP:-ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.35.3-4.1.4-5.8.1}
           env:
             - name: SSL_CERT_DIR
               value: ${AVP_SSL_CERT_DIR:-/etc/ssl/custom}
@@ -124,7 +124,7 @@ spec:
               readOnly: true
         - name: argocd-vault-plugin-helm
           command: [/var/run/argocd/argocd-cmp-server]
-          image: ${IMAGE_AVP:-ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.32.3-3.17.2}
+          image: ${IMAGE_AVP:-ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.35.3-4.1.4-5.8.1}
           env:
             - name: SSL_CERT_DIR
               value: ${AVP_SSL_CERT_DIR:-/etc/ssl/custom}
@@ -150,7 +150,7 @@ spec:
               readOnly: true
         - name: argocd-vault-plugin-kustomize
           command: [/var/run/argocd/argocd-cmp-server]
-          image: ${IMAGE_AVP:-ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.32.3-3.17.2}
+          image: ${IMAGE_AVP:-ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.35.3-4.1.4-5.8.1}
           env:
             - name: SSL_CERT_DIR
               value: ${AVP_SSL_CERT_DIR:-/etc/ssl/custom}


### PR DESCRIPTION
## Summary

- Points the three argocd-vault-plugin CMP sidecars at `ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.35.3-4.1.4-5.8.1` (kustomize v5.8.1 now baked in, plus bumped kubectl 1.35.3 / helm 4.1.4).
- Built + pushed from `stuttgart-things/stuttgart-things#2059` (squash-merged as `0da27999`) and local Dockerfile follow-up edits.

## Why

The `argocd-vault-plugin-kustomize` CMP invokes `sh -c \"kustomize build . | argocd-vault-plugin generate -\"`. The previous image did not ship kustomize, so the sidecar failed silently with `sh: kustomize: not found` and returned empty manifests. Argo CD then reported dependent Applications as Synced with zero resources — a silent deploy-nothing failure. Surfaced while wiring the new `stuttgart-things/argocd` catalog → kind-dev2 consumer overlay, where the remote-base kustomization rendered to nothing.

## Test plan

- [ ] After rollout on platform-sthings, `kubectl exec -n argocd <repo-server-pod> -c argocd-vault-plugin-kustomize -- kustomize version` reports v5.8.1
- [ ] `openebs-root` Application on platform-sthings shows a non-empty `status.resources` and recreates the child `openebs` Application
- [ ] Child `openebs` Application syncs to kind-dev2 (pre-existing hook stall notwithstanding — separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)