### PR TITLE
feat(argocd): add SOPS CMP sidecar (Option C for #96)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,6 +8,20 @@ vars:
   CROSSPLANE_PACKAGE_REGISTRY: ghcr.io
   DAGGER_CROSSPLANE_MODULE: github.com/stuttgart-things/dagger/crossplane
   DAGGER_CROSSPLANE_MODULE_VERSION: v0.0.2
+  DAGGER_DOCKER_MODULE: github.com/stuttgart-things/dagger/docker
+  DAGGER_DOCKER_MODULE_VERSION: main
+
+  # sthings-sops-cmp image (Argo CD CMP sidecar for SOPS).
+  # Tag scheme: sops-age-kustomize-helm — keep in sync with ARG defaults in
+  # cicd/argo-cd/sops-cmp/Dockerfile.
+  SOPS_CMP_CONTEXT: ./cicd/argo-cd/sops-cmp
+  SOPS_CMP_REGISTRY: ghcr.io
+  SOPS_CMP_REPOSITORY: stuttgart-things/sthings-sops-cmp
+  SOPS_CMP_SOPS_VERSION: 3.12.2
+  SOPS_CMP_AGE_VERSION: 1.3.1
+  SOPS_CMP_KUSTOMIZE_VERSION: 5.8.1
+  SOPS_CMP_HELM_VERSION: 4.1.4
+  SOPS_CMP_TAG: "{{.SOPS_CMP_SOPS_VERSION}}-{{.SOPS_CMP_AGE_VERSION}}-{{.SOPS_CMP_KUSTOMIZE_VERSION}}-{{.SOPS_CMP_HELM_VERSION}}"
 
 includes:
   git:
@@ -72,3 +86,39 @@ tasks:
 
         # Run the selected task
         [ -n "$task_name" ] && task "$task_name"
+
+  lint-sops-cmp:
+    desc: Hadolint the sthings-sops-cmp Dockerfile via dagger
+    cmds:
+      - |
+        dagger call -m {{.DAGGER_DOCKER_MODULE}}@{{.DAGGER_DOCKER_MODULE_VERSION}} lint \
+          --src {{.SOPS_CMP_CONTEXT}} \
+          --progress plain
+
+  build-sops-cmp:
+    desc: Build sthings-sops-cmp container image locally via dagger (no push)
+    cmds:
+      - echo "Building {{.SOPS_CMP_REGISTRY}}/{{.SOPS_CMP_REPOSITORY}}:{{.SOPS_CMP_TAG}}"
+      - |
+        dagger call -m {{.DAGGER_DOCKER_MODULE}}@{{.DAGGER_DOCKER_MODULE_VERSION}} build \
+          --src {{.SOPS_CMP_CONTEXT}} \
+          --progress plain
+
+  push-sops-cmp:
+    desc: Build & push sthings-sops-cmp to ghcr.io via dagger
+    preconditions:
+      - sh: test -n "$GITHUB_USER"
+        msg: "GITHUB_USER env var must be set"
+      - sh: test -n "$GITHUB_TOKEN"
+        msg: "GITHUB_TOKEN env var must be set"
+    cmds:
+      - echo "Pushing {{.SOPS_CMP_REGISTRY}}/{{.SOPS_CMP_REPOSITORY}}:{{.SOPS_CMP_TAG}}"
+      - |
+        dagger call -m {{.DAGGER_DOCKER_MODULE}}@{{.DAGGER_DOCKER_MODULE_VERSION}} build-and-push \
+          --source {{.SOPS_CMP_CONTEXT}} \
+          --repository-name {{.SOPS_CMP_REPOSITORY}} \
+          --registry-url {{.SOPS_CMP_REGISTRY}} \
+          --tag {{.SOPS_CMP_TAG}} \
+          --registry-username env:GITHUB_USER \
+          --registry-password env:GITHUB_TOKEN \
+          --progress plain

--- a/cicd/argo-cd/README.md
+++ b/cicd/argo-cd/README.md
@@ -193,6 +193,8 @@ EOF
 | `AVP_TRUST_BUNDLE_CONFIGMAP` | `cluster-trust-bundle` | ConfigMap with CA bundle (from trust-manager) |
 | `AVP_TRUST_BUNDLE_KEY` | `trust-bundle.pem` | Key in the trust bundle ConfigMap |
 | `AVP_SSL_CERT_DIR` | `/etc/ssl/custom` | Directory to mount the CA bundle into (sets `SSL_CERT_DIR`) |
+| `IMAGE_SOPS_CMP` | `ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4` | SOPS CMP sidecar image (sops + age + kustomize + helm) |
+| `ARGOCD_SOPS_AGE_KEY_SECRET` | `argocd-sops-age-key` | Secret with `keys.txt` (age private keys) mounted at `/.config/sops/age/` |
 | `ARGO_CD_PASSWORD_MTIME` | `2024-09-16T12:51:06UTC` | Admin password modification time |
 | `ARGO_CD_EXTENSIONS_ENABLED` | `false` | Enable Argo CD UI extensions (spawns the extensions init container on the server) |
 | `ARGO_CD_ROLLOUT_EXTENSION_URL` | `https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar` | Download URL of the [argo-rollouts UI extension](https://github.com/argoproj-labs/rollout-extension) (only used when `ARGO_CD_EXTENSIONS_ENABLED=true`) |
@@ -224,6 +226,33 @@ Three AVP sidecar containers run alongside the repo-server for secret injection:
 
 Sidecar image: `ghcr.io/stuttgart-things/sthings-avp:1.18.1-1.32.3-3.17.2` (AVP 1.18.1, kubectl 1.32.3, kustomize 3.17.2)
 
+## SOPS Plugin Sidecars
+
+Three SOPS sidecar containers run alongside the repo-server for decrypting SOPS-encrypted manifests (Option C from [#96](https://github.com/stuttgart-things/flux/issues/96)):
+
+| Plugin | Purpose |
+|---|---|
+| `sops-decrypt` | Emits only the files it decrypts — apps where every manifest is a `*.enc.yaml` |
+| `sops-decrypt-kustomize` | Decrypts `*.enc.yaml` in place, then runs `kustomize build` |
+| `sops-decrypt-helm` | Decrypts `*.enc.yaml` in place, then runs `helm template` |
+
+Sidecar image: `ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4` (sops 3.12.2, age 1.3.1, kustomize 5.8.1, helm 4.1.4). Built via `task build-sops-cmp` / `task push-sops-cmp`, Dockerfile at `cicd/argo-cd/sops-cmp/Dockerfile`.
+
+All three discover on the presence of any `*.enc.yaml` file. Because that rule overlaps with the AVP kustomize/helm discovery, apps **must** select the plugin explicitly on the `Application`:
+
+```yaml
+spec:
+  source:
+    plugin:
+      name: sops-decrypt-kustomize
+```
+
+### Age key contract
+
+The sidecars read the age private key from `/.config/sops/age/keys.txt`, sourced from a Secret named `argocd-sops-age-key` (override via `ARGOCD_SOPS_AGE_KEY_SECRET`). The volume is `optional: true` — the sidecars start without it, but decryption returns an error at generate time until the Secret exists.
+
+How the Secret gets into the cluster is **out of scope for this flux app**. Pick whatever fits the consumer's stack: `kubectl create secret generic argocd-sops-age-key --from-file=keys.txt=...`, a separate Flux Kustomization with a SOPS-encrypted Secret manifest, `external-secrets`, `sealed-secrets`, etc. The Secret must have a `keys.txt` key containing one or more `AGE-SECRET-KEY-...` lines.
+
 ## Verify
 
 ```bash
@@ -244,9 +273,13 @@ kubectl get certificates -n argocd
 
 # Check CMP plugins are loaded
 kubectl get cm argocd-cmp-cm -n argocd -o yaml | grep 'name: argocd-vault-plugin'
+kubectl get cm argocd-cmp-cm -n argocd -o yaml | grep 'name: sops-decrypt'
 
-# Check AVP sidecar containers
+# Check repo-server sidecar containers (AVP + SOPS)
 kubectl get pods -n argocd -l app.kubernetes.io/component=repo-server -o jsonpath='{.items[0].spec.containers[*].name}'
+
+# Age-key Secret present?
+kubectl get secret argocd-sops-age-key -n argocd
 ```
 
 See also: [claims CLI](https://github.com/stuttgart-things/claims) | [claim-machinery-api](https://github.com/stuttgart-things/claim-machinery-api)

--- a/cicd/argo-cd/release.yaml
+++ b/cicd/argo-cd/release.yaml
@@ -94,6 +94,76 @@ spec:
                 - |
                   helm template "${ARGOCD_APP_NAME}" -f <(echo "${ARGOCD_ENV_HELM_VALUES}") --include-crds . -n "${ARGOCD_APP_NAMESPACE}" | argocd-vault-plugin generate -
             lockRepo: false
+          sops-decrypt:
+            allowConcurrency: true
+            discover:
+              find:
+                command:
+                  - sh
+                  - "-c"
+                  - "find . -name '*.enc.yaml' | head -1"
+            generate:
+              command:
+                - sh
+                - "-c"
+                - |
+                  set -e
+                  # Emit ONLY files the plugin itself decrypts, in a stable order.
+                  # Apps mixing encrypted + plaintext manifests should use
+                  # sops-decrypt-kustomize and list both in resources:.
+                  find . -name '*.enc.yaml' | sort | while read -r f; do
+                    sops -d "$f"
+                    echo '---'
+                  done
+            lockRepo: false
+          sops-decrypt-kustomize:
+            allowConcurrency: true
+            discover:
+              find:
+                command:
+                  - sh
+                  - "-c"
+                  - "find . -name '*.enc.yaml' | head -1"
+            generate:
+              command:
+                - sh
+                - "-c"
+                - |
+                  set -e
+                  find . -name '*.enc.yaml' | while read -r f; do
+                    sops -d "$f" > "${f%.enc.yaml}.yaml"
+                    rm -f "$f"
+                  done
+                  kustomize build .
+            lockRepo: false
+          sops-decrypt-helm:
+            allowConcurrency: true
+            discover:
+              find:
+                command:
+                  - sh
+                  - "-c"
+                  - "find . -name '*.enc.yaml' | head -1"
+            init:
+              command:
+                - sh
+                - "-c"
+                - "helm dependency update"
+            generate:
+              command:
+                - sh
+                - "-c"
+                - |
+                  set -e
+                  find . -name '*.enc.yaml' | while read -r f; do
+                    sops -d "$f" > "${f%.enc.yaml}.yaml"
+                    rm -f "$f"
+                  done
+                  helm template "${ARGOCD_APP_NAME}" \
+                    -f <(echo "${ARGOCD_ENV_HELM_VALUES}") \
+                    --include-crds . \
+                    -n "${ARGOCD_APP_NAMESPACE}"
+            lockRepo: false
     repoServer:
       extraContainers:
         - name: argocd-vault-plugin
@@ -174,6 +244,63 @@ spec:
               subPath: ${AVP_TRUST_BUNDLE_KEY:-trust-bundle.pem}
               name: trust-bundle
               readOnly: true
+        - name: sops-decrypt
+          command: [/var/run/argocd/argocd-cmp-server]
+          image: ${IMAGE_SOPS_CMP:-ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+          volumeMounts:
+            - mountPath: /var/run/argocd
+              name: var-files
+            - mountPath: /home/argocd/cmp-server/plugins
+              name: plugins
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+              subPath: sops-decrypt.yaml
+              name: argocd-cmp-cm
+            - mountPath: /.config/sops/age
+              name: sops-age-key
+              readOnly: true
+        - name: sops-decrypt-kustomize
+          command: [/var/run/argocd/argocd-cmp-server]
+          image: ${IMAGE_SOPS_CMP:-ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+          volumeMounts:
+            - mountPath: /var/run/argocd
+              name: var-files
+            - mountPath: /home/argocd/cmp-server/plugins
+              name: plugins
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+              subPath: sops-decrypt-kustomize.yaml
+              name: argocd-cmp-cm
+            - mountPath: /.config/sops/age
+              name: sops-age-key
+              readOnly: true
+        - name: sops-decrypt-helm
+          command: [/var/run/argocd/argocd-cmp-server]
+          image: ${IMAGE_SOPS_CMP:-ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+          volumeMounts:
+            - mountPath: /var/run/argocd
+              name: var-files
+            - mountPath: /home/argocd/cmp-server/plugins
+              name: plugins
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+              subPath: sops-decrypt-helm.yaml
+              name: argocd-cmp-cm
+            - mountPath: /.config/sops/age
+              name: sops-age-key
+              readOnly: true
       volumes:
         - name: argocd-cmp-cm
           configMap:
@@ -181,6 +308,10 @@ spec:
         - name: trust-bundle
           configMap:
             name: ${AVP_TRUST_BUNDLE_CONFIGMAP:-cluster-trust-bundle}
+            optional: true
+        - name: sops-age-key
+          secret:
+            secretName: ${ARGOCD_SOPS_AGE_KEY_SECRET:-argocd-sops-age-key}
             optional: true
         - name: helmfile-tmp
           emptyDir: {}

--- a/cicd/argo-cd/sops-cmp/Dockerfile
+++ b/cicd/argo-cd/sops-cmp/Dockerfile
@@ -1,0 +1,121 @@
+# syntax=docker/dockerfile:1.7
+
+# sthings-sops-cmp: Argo CD Config Management Plugin sidecar image.
+# Mirrors the sthings-avp pattern: ships pinned sops + age + kustomize + helm,
+# runs as UID 999 under /home/argocd, expects /var/run/argocd/argocd-cmp-server
+# to be provided via the shared volume from the argocd-repo-server init container.
+#
+# Tag scheme: sops-age-kustomize-helm, e.g. 3.12.2-1.3.1-5.8.1-4.1.4
+#
+# Build via the stuttgart-things dagger/docker module:
+#   task build-sops-cmp       # local build only
+#   task push-sops-cmp        # build + push to ghcr.io (needs GITHUB_USER/GITHUB_TOKEN)
+#
+# Or directly with buildx:
+#   docker buildx build \
+#     --platform linux/amd64,linux/arm64 \
+#     --build-arg SOPS_VERSION=3.12.2 \
+#     --build-arg AGE_VERSION=1.3.1 \
+#     --build-arg KUSTOMIZE_VERSION=5.8.1 \
+#     --build-arg HELM_VERSION=4.1.4 \
+#     -t ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4 \
+#     --push .
+
+ARG SOPS_VERSION=3.12.2
+ARG AGE_VERSION=1.3.1
+ARG KUSTOMIZE_VERSION=5.8.1
+ARG HELM_VERSION=4.1.4
+
+# ---------- Stage 1: download and verify tools ----------
+FROM --platform=${BUILDPLATFORM} alpine:3.21 AS tools
+
+ARG SOPS_VERSION
+ARG AGE_VERSION
+ARG KUSTOMIZE_VERSION
+ARG HELM_VERSION
+ARG TARGETARCH
+
+RUN apk add --no-cache curl tar ca-certificates
+
+WORKDIR /tmp/dl
+
+# sops (static Go binary, released directly)
+RUN curl -fsSL -o /usr/local/bin/sops \
+      "https://github.com/getsops/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux.${TARGETARCH}" \
+ && chmod +x /usr/local/bin/sops \
+ && /usr/local/bin/sops --version
+
+# age + age-keygen
+RUN curl -fsSL -o age.tgz \
+      "https://github.com/FiloSottile/age/releases/download/v${AGE_VERSION}/age-v${AGE_VERSION}-linux-${TARGETARCH}.tar.gz" \
+ && tar -xzf age.tgz \
+ && mv age/age         /usr/local/bin/age \
+ && mv age/age-keygen  /usr/local/bin/age-keygen \
+ && chmod +x /usr/local/bin/age /usr/local/bin/age-keygen \
+ && /usr/local/bin/age --version
+
+# kustomize
+RUN curl -fsSL -o kustomize.tgz \
+      "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz" \
+ && tar -xzf kustomize.tgz \
+ && mv kustomize /usr/local/bin/kustomize \
+ && chmod +x /usr/local/bin/kustomize \
+ && /usr/local/bin/kustomize version
+
+# helm
+RUN curl -fsSL -o helm.tgz \
+      "https://get.helm.sh/helm-v${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+ && tar -xzf helm.tgz \
+ && mv "linux-${TARGETARCH}/helm" /usr/local/bin/helm \
+ && chmod +x /usr/local/bin/helm \
+ && /usr/local/bin/helm version --short
+
+# ---------- Stage 2: final runtime image ----------
+FROM alpine:3.21
+
+ARG SOPS_VERSION
+ARG AGE_VERSION
+ARG KUSTOMIZE_VERSION
+ARG HELM_VERSION
+
+LABEL org.opencontainers.image.source="https://github.com/stuttgart-things/flux" \
+      org.opencontainers.image.title="sthings-sops-cmp" \
+      org.opencontainers.image.description="Argo CD CMP sidecar for SOPS-encrypted manifests" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      sops.version="${SOPS_VERSION}" \
+      age.version="${AGE_VERSION}" \
+      kustomize.version="${KUSTOMIZE_VERSION}" \
+      helm.version="${HELM_VERSION}"
+
+# bash: for `sh -c` generate scripts using process substitution if needed
+# git: helm chart dependency fetch, Argo CD repo ops
+# findutils: GNU `find` semantics for discover rules (alpine's busybox find is close but not identical)
+#
+# Note: UID 999 is pinned to match `runAsUser: 999` in the Argo CD repo-server
+# sidecar. GID 999 is intentionally NOT pinned — alpine 3.21 ships a pre-existing
+# `ping` group at GID 999, so we let addgroup auto-assign a free GID instead.
+RUN apk add --no-cache bash ca-certificates findutils git \
+ && addgroup -S argocd \
+ && adduser  -u 999 -S -G argocd -h /home/argocd argocd \
+ && mkdir -p /home/argocd/cmp-server/plugins \
+             /home/argocd/cmp-server/config \
+             /.config/sops/age \
+ && chown -R argocd:argocd /home/argocd /.config
+
+COPY --from=tools /usr/local/bin/sops        /usr/local/bin/sops
+COPY --from=tools /usr/local/bin/age         /usr/local/bin/age
+COPY --from=tools /usr/local/bin/age-keygen  /usr/local/bin/age-keygen
+COPY --from=tools /usr/local/bin/kustomize   /usr/local/bin/kustomize
+COPY --from=tools /usr/local/bin/helm        /usr/local/bin/helm
+
+# SOPS resolves age keys from SOPS_AGE_KEY_FILE; release.yaml mounts the key
+# into /.config/sops/age/keys.txt (read-only) to match the standard path.
+ENV XDG_CONFIG_HOME=/.config \
+    SOPS_AGE_KEY_FILE=/.config/sops/age/keys.txt
+
+USER 999
+WORKDIR /home/argocd
+
+# The entrypoint is provided at runtime via the shared volume:
+#   command: [/var/run/argocd/argocd-cmp-server]
+# See cicd/argo-cd/release.yaml repoServer.extraContainers.


### PR DESCRIPTION
## Summary

Implements [Option C from #96](https://github.com/stuttgart-things/flux/issues/96#issuecomment-4275065952): a custom CMP plugin for SOPS-encrypted manifests alongside the existing AVP sidecars. Zero rewrapping of existing `.enc.yaml` files (drop-in compatible with the `dagger/sops` encrypt helper documented in `CLAUDE.md`).

- **New image** `sthings-sops-cmp` — multi-arch, pinned `sops 3.12.2 + age 1.3.1 + kustomize 5.8.1 + helm 4.1.4`, UID 999, mirrors the `sthings-avp` layout.
- **Three CMP plugins** on the Argo CD repo-server:
  - `sops-decrypt` — apps where every manifest is encrypted (emits only the files it decrypts)
  - `sops-decrypt-kustomize` — decrypt in place, then `kustomize build`
  - `sops-decrypt-helm` — decrypt in place, then `helm template`
- **Age key contract only** — Secret provisioning is explicitly out of scope (volume is `optional: true`); consumers wire it however they like (`kubectl`, separate Flux Kustomization, external-secrets, sealed-secrets).
- **Taskfile** — `lint-sops-cmp` / `build-sops-cmp` / `push-sops-cmp` via the `stuttgart-things/dagger/docker` module. Image `ghcr.io/stuttgart-things/sthings-sops-cmp:3.12.2-1.3.1-5.8.1-4.1.4` is already published.

Known follow-ups:
- Dagger module doesn't support `--build-arg` passthrough yet — tracked at stuttgart-things/dagger#231. Unblocked for now via ARG defaults.
- GH Actions workflow to replace the local `task push-sops-cmp` — deferred.

## Test plan

- [ ] PR merges cleanly, Flux reconciles `argo-cd` Kustomization without error
- [ ] `kubectl get pods -n argocd -l app.kubernetes.io/component=repo-server` shows 3 AVP + 3 SOPS sidecars
- [ ] `kubectl get cm argocd-cmp-cm -n argocd -o yaml | grep 'name: sops-decrypt'` lists all three plugins
- [ ] Create a test `Application` with `spec.source.plugin.name: sops-decrypt-kustomize` referencing a SOPS-encrypted Secret; verify decryption after `argocd-sops-age-key` Secret is present
- [ ] Confirm existing AVP-based Applications still sync unchanged (no discovery collision regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)