### PR TITLE
feat(harbor,cert-manager): https externalURL + extra-certificate component

### DIFF
--- a/apps/harbor/release.yaml
+++ b/apps/harbor/release.yaml
@@ -20,7 +20,7 @@ spec:
         namespace: ${HARBOR_NAMESPACE:-harbor}
       interval: 12h
   values:
-    externalURL: ${HARBOR_HOSTNAME}.${HARBOR_DOMAIN}
+    externalURL: https://${HARBOR_HOSTNAME}.${HARBOR_DOMAIN}
     clusterDomain: cluster.local
     adminPassword: ${HARBOR_ADMIN_PASSWORD}
 

--- a/infra/cert-manager/components/extra-certificate/certificate.yaml
+++ b/infra/cert-manager/components/extra-certificate/certificate.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${EXTRA_CERT_NAME}
+  namespace: ${EXTRA_CERT_NAMESPACE:-default}
+spec:
+  secretName: ${EXTRA_CERT_SECRET_NAME}
+  issuerRef:
+    name: ${EXTRA_CERT_ISSUER:-vault-pki}
+    kind: ${EXTRA_CERT_ISSUER_KIND:-ClusterIssuer}
+  commonName: "${EXTRA_CERT_COMMON_NAME}"
+  dnsNames:
+    - "${EXTRA_CERT_COMMON_NAME}"
+  duration: ${EXTRA_CERT_DURATION:-2160h}
+  renewBefore: ${EXTRA_CERT_RENEW_BEFORE:-360h}

--- a/infra/cert-manager/components/extra-certificate/kustomization.yaml
+++ b/infra/cert-manager/components/extra-certificate/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - certificate.yaml


### PR DESCRIPTION
## Summary
- **harbor**: prefix \`externalURL\` with \`https://\` so harbor-core emits HTTPS bearer-token realms. Without the scheme, the Bitnami chart defaults the env var \`EXT_ENDPOINT\` to \`http://...\`, which breaks Docker pulls via the \`harbor-project-proxy\` subdomain (Docker daemon refuses to downgrade to http for token exchange).
- **cert-manager**: add \`extra-certificate\` component to issue additional \`Certificate\` resources (e.g. a second wildcard cert for \`*.harbor.\${DOMAIN}\`) without colliding with the bootstrap \`selfsigned\` component (which also creates ClusterIssuers and the cluster CA).

## Why
Discovered while testing the Docker Hub proxy-cache project on \`platform-sthings\` cluster. The harbor-project-proxy correctly rewrites the \`Host\` header on the bearer realm but preserves the upstream scheme — so once Harbor's \`EXT_ENDPOINT\` is HTTPS, the chain works end-to-end.

## Test plan
- [ ] Apply on platform-sthings, verify \`docker pull docker.harbor.platform.sthings-vsphere.labul.sva.de/library/nginx\` succeeds
- [ ] Verify existing Harbor UI/API access (\`harbor.\${DOMAIN}\`) is unchanged
- [ ] Verify \`extra-certificate\` component renders correctly via \`flux build kustomization\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)