### PR TITLE
fix(cert-manager): quote substitution placeholders in extra-certificate

### DIFF
--- a/infra/cert-manager/components/extra-certificate/certificate.yaml
+++ b/infra/cert-manager/components/extra-certificate/certificate.yaml
@@ -2,15 +2,15 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: ${EXTRA_CERT_NAME}
-  namespace: ${EXTRA_CERT_NAMESPACE:-default}
+  name: "${EXTRA_CERT_NAME}"
+  namespace: "${EXTRA_CERT_NAMESPACE:-default}"
 spec:
-  secretName: ${EXTRA_CERT_SECRET_NAME}
+  secretName: "${EXTRA_CERT_SECRET_NAME}"
   issuerRef:
-    name: ${EXTRA_CERT_ISSUER:-vault-pki}
-    kind: ${EXTRA_CERT_ISSUER_KIND:-ClusterIssuer}
+    name: "${EXTRA_CERT_ISSUER:-vault-pki}"
+    kind: "${EXTRA_CERT_ISSUER_KIND:-ClusterIssuer}"
   commonName: "${EXTRA_CERT_COMMON_NAME}"
   dnsNames:
     - "${EXTRA_CERT_COMMON_NAME}"
-  duration: ${EXTRA_CERT_DURATION:-2160h}
-  renewBefore: ${EXTRA_CERT_RENEW_BEFORE:-360h}
+  duration: "${EXTRA_CERT_DURATION:-2160h}"
+  renewBefore: "${EXTRA_CERT_RENEW_BEFORE:-360h}"


### PR DESCRIPTION
## Summary
Quote all \`\${VAR:-default}\` placeholders in \`extra-certificate/certificate.yaml\` so the source YAML parses cleanly before Flux runs envsubst.

## Why
Flux's postBuild parses the kustomize-built YAML *before* substitution. An unquoted \`\${VAR:-default}\` value contains a literal \`:\`, which the YAML parser treats as a map separator and rejects with \`YAMLToJSON: did not find expected alphabetic or numeric character\`.

Tested live on platform-sthings — \`cert-harbor-wildcard\` Kustomization failed with this exact error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)