### PR TITLE
feat(velero): add infra/velero base with S3/MinIO + optional ESO

### DIFF
--- a/docs/infra/index.md
+++ b/docs/infra/index.md
@@ -13,6 +13,7 @@ Infrastructure components for Kubernetes clusters.
 | [NFS CSI Driver](nfs-csi.md) | `csi-driver-nfs` | `v4.13.1` | NFS CSI driver with StorageClass provisioning |
 | [OpenEBS](openebs.md) | `openebs` | `4.2.0` | Container-attached storage (hostpath) |
 | [Prometheus](prometheus.md) | `prometheus` | `28.13.0` | Monitoring with Gateway API HTTPRoute |
+| [Velero](velero.md) | `velero` | `9.0.0` | Cluster + PV backup/restore, S3-compatible (MinIO) |
 
 ## Deployment Order
 

--- a/docs/infra/velero.md
+++ b/docs/infra/velero.md
@@ -1,0 +1,91 @@
+# Velero
+
+HashiCorp Velero install for cluster and persistent volume backup/restore, pre-wired for S3-compatible storage (default: MinIO).
+
+Anchors the work in [#111](https://github.com/stuttgart-things/flux/issues/111) (sharded Crossplane control planes) and [#115](https://github.com/stuttgart-things/flux/issues/115) (restore hooks for provider readiness).
+
+## Prerequisites
+
+- An S3-compatible bucket (MinIO, AWS S3, etc.) and credentials for it
+- For **ESO credential mode**: External Secrets Operator installed and a `ClusterSecretStore` (e.g. wired to Vault `sthings.lab`)
+
+## Credential modes
+
+The base layer creates the `cloud-credentials` Secret via the `sthings-cluster` helper chart using substitution variables. To use ESO instead, enable the `components/external-secret/` kustomize Component and patch out the helper-chart HelmRelease — see the [README](https://github.com/stuttgart-things/flux/blob/main/infra/velero/README.md#2-external-secrets-operator-opt-in) for the patch.
+
+## Deployment
+
+### GitRepository
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-apps
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  ref:
+    tag: <version>
+  url: https://github.com/stuttgart-things/flux.git
+```
+
+### Kustomization (substitution mode)
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./infra/velero
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      VELERO_BUCKET: cluster-backups
+      VELERO_S3_ENDPOINT: https://minio.sthings.lab
+      VELERO_S3_REGION: minio
+    substituteFrom:
+      - kind: Secret
+        name: velero-s3-credentials   # SOPS-encrypted, contains VELERO_S3_ACCESS_KEY / VELERO_S3_SECRET_KEY
+```
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `VELERO_NAMESPACE` | `velero` | Target namespace |
+| `VELERO_VERSION` | `9.0.0` | velero Helm chart version |
+| `VELERO_PLUGIN_AWS_VERSION` | `v1.13.0` | velero-plugin-for-aws image tag |
+| `VELERO_BUCKET` | *(required)* | S3 bucket name |
+| `VELERO_S3_ENDPOINT` | *(required)* | S3 endpoint URL |
+| `VELERO_S3_REGION` | `minio` | S3 region |
+| `VELERO_S3_FORCE_PATH_STYLE` | `true` | Path-style URLs (MinIO requirement) |
+| `VELERO_S3_INSECURE_SKIP_TLS_VERIFY` | `false` | Skip TLS verify on S3 endpoint |
+| `VELERO_CREDENTIALS_SECRET_NAME` | `cloud-credentials` | Secret consumed by Velero |
+| `VELERO_S3_ACCESS_KEY` | *(required, substitution mode)* | MinIO access key |
+| `VELERO_S3_SECRET_KEY` | *(required, substitution mode)* | MinIO secret key |
+| `VELERO_SNAPSHOTS_ENABLED` | `false` | Enable volume snapshots |
+| `VELERO_DEPLOY_NODE_AGENT` | `false` | Deploy node-agent for filesystem backup |
+| `VELERO_METRICS_ENABLED` | `true` | Expose Prometheus metrics |
+| `VELERO_SERVICE_MONITOR_ENABLED` | `false` | Create a Prometheus ServiceMonitor |
+| `VELERO_ESO_SECRET_STORE_NAME` | `vault-cluster` | ClusterSecretStore name (ESO mode) |
+| `VELERO_ESO_SECRET_PATH` | `kv/data/velero/s3` | Vault KV path (ESO mode) |
+
+See [README](https://github.com/stuttgart-things/flux/blob/main/infra/velero/README.md) for the full list, including all ESO mode variables.
+
+## Notes
+
+- The Velero CRDs are installed by the chart; `cleanUpCRDs: false` keeps them in place across uninstalls so that scheduled-backup metadata survives.
+- `velero-plugin-for-aws` is used for all S3-compatible providers including MinIO — there is no separate MinIO plugin.
+- Scheduled backups are not defined in this base; create `Schedule` resources separately or extend the HelmRelease `values.schedules`.

--- a/infra/velero/README.md
+++ b/infra/velero/README.md
@@ -1,0 +1,73 @@
+# velero
+
+HashiCorp Velero install for cluster and PV backup/restore, wired for S3-compatible storage (default: MinIO).
+
+Required by parent issue [#111](https://github.com/stuttgart-things/flux/issues/111) (sharded Crossplane control planes) and child issue [#115](https://github.com/stuttgart-things/flux/issues/115) (restore-hook gating for provider readiness).
+
+## Credential modes
+
+Two mutually-exclusive ways to populate the `cloud-credentials` Secret consumed by the Velero HelmRelease:
+
+### 1. Substitution (default)
+
+The base `pre-release.yaml` uses the `sthings-cluster` helper chart to create the Secret from Flux `postBuild.substitute` values (`VELERO_S3_ACCESS_KEY`, `VELERO_S3_SECRET_KEY`). Pair with SOPS for the actual credential values:
+
+```yaml
+postBuild:
+  substituteFrom:
+    - kind: Secret
+      name: velero-s3-credentials   # SOPS-encrypted in the consumer overlay
+```
+
+### 2. External Secrets Operator (opt-in)
+
+Use the kustomize Component at `components/external-secret/` to pull credentials from Vault via ESO instead. Enable it in your consumer Flux `Kustomization` overlay and patch out the `pre-release.yaml` resource so the two don't fight over `cloud-credentials`:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+spec:
+  path: ./infra/velero
+  components:
+    - ./components/external-secret
+  patches:
+    - target:
+        kind: HelmRelease
+        name: velero-credentials
+      patch: |
+        $patch: delete
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata:
+          name: velero-credentials
+          namespace: velero
+```
+
+Requires External Secrets Operator and a `ClusterSecretStore` already installed in the cluster.
+
+## Required variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `VELERO_NAMESPACE` | `velero` | Target namespace |
+| `VELERO_VERSION` | `9.0.0` | velero Helm chart version |
+| `VELERO_PLUGIN_AWS_VERSION` | `v1.13.0` | velero-plugin-for-aws image tag |
+| `VELERO_BUCKET` | *(required)* | S3 bucket name |
+| `VELERO_S3_ENDPOINT` | *(required)* | S3 endpoint URL (MinIO URL for self-hosted) |
+| `VELERO_S3_REGION` | `minio` | S3 region (MinIO accepts any string) |
+| `VELERO_S3_FORCE_PATH_STYLE` | `true` | Path-style URLs (required for MinIO) |
+| `VELERO_S3_INSECURE_SKIP_TLS_VERIFY` | `false` | Skip TLS verify on S3 endpoint |
+| `VELERO_CREDENTIALS_SECRET_NAME` | `cloud-credentials` | Secret consumed by Velero |
+| `VELERO_S3_ACCESS_KEY` | *(required in mode 1)* | MinIO access key |
+| `VELERO_S3_SECRET_KEY` | *(required in mode 1)* | MinIO secret key |
+| `VELERO_SNAPSHOTS_ENABLED` | `false` | Enable volume snapshots |
+| `VELERO_DEPLOY_NODE_AGENT` | `false` | Deploy node-agent for filesystem backup (Kopia/Restic) |
+| `VELERO_METRICS_ENABLED` | `true` | Expose Prometheus metrics |
+| `VELERO_SERVICE_MONITOR_ENABLED` | `false` | Create a Prometheus ServiceMonitor |
+| `STHINGS_CLUSTER_VERSION` | `0.3.20` | sthings-cluster helper chart version (mode 1 only) |
+| `VELERO_ESO_SECRET_STORE_NAME` | `vault-cluster` | ClusterSecretStore name (mode 2 only) |
+| `VELERO_ESO_SECRET_STORE_KIND` | `ClusterSecretStore` | Secret store kind (mode 2 only) |
+| `VELERO_ESO_SECRET_PATH` | `kv/data/velero/s3` | Vault KV path holding the S3 credentials (mode 2 only) |
+| `VELERO_ESO_ACCESS_KEY_PROPERTY` | `access_key` | KV property for access key (mode 2 only) |
+| `VELERO_ESO_SECRET_KEY_PROPERTY` | `secret_key` | KV property for secret key (mode 2 only) |
+| `VELERO_ESO_REFRESH_INTERVAL` | `1h` | ESO refresh interval (mode 2 only) |

--- a/infra/velero/components/external-secret/external-secret.yaml
+++ b/infra/velero/components/external-secret/external-secret.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: velero-cloud-credentials
+  namespace: ${VELERO_NAMESPACE:-velero}
+spec:
+  refreshInterval: ${VELERO_ESO_REFRESH_INTERVAL:-1h}
+  secretStoreRef:
+    name: ${VELERO_ESO_SECRET_STORE_NAME:-vault-cluster}
+    kind: ${VELERO_ESO_SECRET_STORE_KIND:-ClusterSecretStore}
+  target:
+    name: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        cloud: |
+          [default]
+          aws_access_key_id={{ .access_key }}
+          aws_secret_access_key={{ .secret_key }}
+  data:
+    - secretKey: access_key
+      remoteRef:
+        key: ${VELERO_ESO_SECRET_PATH:-kv/data/velero/s3}
+        property: ${VELERO_ESO_ACCESS_KEY_PROPERTY:-access_key}
+    - secretKey: secret_key
+      remoteRef:
+        key: ${VELERO_ESO_SECRET_PATH:-kv/data/velero/s3}
+        property: ${VELERO_ESO_SECRET_KEY_PROPERTY:-secret_key}

--- a/infra/velero/components/external-secret/kustomization.yaml
+++ b/infra/velero/components/external-secret/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secret.yaml

--- a/infra/velero/kustomization.yaml
+++ b/infra/velero/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - pre-release.yaml
+  - release.yaml

--- a/infra/velero/pre-release.yaml
+++ b/infra/velero/pre-release.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero-credentials
+  namespace: ${VELERO_NAMESPACE:-velero}
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: sthings-cluster
+      version: ${STHINGS_CLUSTER_VERSION:-0.3.20}
+      sourceRef:
+        kind: HelmRepository
+        name: stuttgart-things
+        namespace: ${VELERO_NAMESPACE:-velero}
+      interval: 12h
+  values:
+    customresources:
+      cloud-credentials:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
+          namespace: ${VELERO_NAMESPACE:-velero}
+        type: Opaque
+        stringData:
+          cloud: |
+            [default]
+            aws_access_key_id=${VELERO_S3_ACCESS_KEY}
+            aws_secret_access_key=${VELERO_S3_SECRET_KEY}

--- a/infra/velero/release.yaml
+++ b/infra/velero/release.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero
+  namespace: ${VELERO_NAMESPACE:-velero}
+spec:
+  dependsOn:
+    - name: velero-credentials
+      namespace: ${VELERO_NAMESPACE:-velero}
+  interval: 30m
+  timeout: 10m
+  chart:
+    spec:
+      chart: velero
+      version: ${VELERO_VERSION:-9.0.0}
+      sourceRef:
+        kind: HelmRepository
+        name: vmware-tanzu
+        namespace: ${VELERO_NAMESPACE:-velero}
+      interval: 12h
+  values:
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:${VELERO_PLUGIN_AWS_VERSION:-v1.13.0}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - name: plugins
+            mountPath: /target
+    credentials:
+      useSecret: true
+      existingSecret: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
+    configuration:
+      backupStorageLocation:
+        - name: default
+          provider: aws
+          bucket: ${VELERO_BUCKET}
+          default: true
+          config:
+            region: ${VELERO_S3_REGION:-minio}
+            s3ForcePathStyle: "${VELERO_S3_FORCE_PATH_STYLE:-true}"
+            s3Url: ${VELERO_S3_ENDPOINT}
+            insecureSkipTLSVerify: "${VELERO_S3_INSECURE_SKIP_TLS_VERIFY:-false}"
+      volumeSnapshotLocation:
+        - name: default
+          provider: aws
+          config:
+            region: ${VELERO_S3_REGION:-minio}
+    snapshotsEnabled: ${VELERO_SNAPSHOTS_ENABLED:-false}
+    deployNodeAgent: ${VELERO_DEPLOY_NODE_AGENT:-false}
+    metrics:
+      enabled: ${VELERO_METRICS_ENABLED:-true}
+      serviceMonitor:
+        enabled: ${VELERO_SERVICE_MONITOR_ENABLED:-false}
+        additionalLabels:
+          release: prometheus
+    schedules: {}
+    upgradeJob:
+      enabled: false
+    cleanUpCRDs: false

--- a/infra/velero/requirements.yaml
+++ b/infra/velero/requirements.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${VELERO_NAMESPACE:-velero}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vmware-tanzu
+  namespace: ${VELERO_NAMESPACE:-velero}
+spec:
+  interval: 1h
+  url: https://vmware-tanzu.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: stuttgart-things
+  namespace: ${VELERO_NAMESPACE:-velero}
+spec:
+  type: oci
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - NFS CSI Driver: infra/nfs-csi.md
       - OpenEBS: infra/openebs.md
       - Prometheus: infra/prometheus.md
+      - Velero: infra/velero.md
   - CI/CD:
       - Overview: cicd/index.md
       - Crossplane: cicd/crossplane.md


### PR DESCRIPTION
## Summary

- Adds `infra/velero/` Flux component: Namespace, HelmRepository (vmware-tanzu), HelmRelease (chart `9.0.0` default) with `velero-plugin-for-aws` and MinIO-friendly S3 defaults (path-style URLs, region `minio`).
- Dual credential model: base creates `cloud-credentials` via the `sthings-cluster` helper from substitution variables (matches `apps/minio` pattern); opt-in `components/external-secret/` kustomize Component sources the same Secret from Vault via ESO.
- Adds `infra/velero/README.md`, `docs/infra/velero.md`, nav entry in `mkdocs.yml`, table row in `docs/infra/index.md`.

Unblocks #115 (Velero restore hooks for Crossplane provider readiness) and the backup scope in parent #111.

## Test plan

- [ ] Apply via Flux `Kustomization` pointing at `./infra/velero` with `VELERO_BUCKET`, `VELERO_S3_ENDPOINT`, and SOPS-encrypted `VELERO_S3_ACCESS_KEY`/`VELERO_S3_SECRET_KEY` substitution
- [ ] Confirm `cloud-credentials` Secret reconciled and Velero pod healthy
- [ ] Run `velero backup-location get` — `default` location should be `Available`
- [ ] Smoke-test a namespace backup + restore against the MinIO bucket
- [ ] Verify ESO opt-in mode by enabling `components/external-secret/` and patching out `velero-credentials` HelmRelease

🤖 Generated with [Claude Code](https://claude.com/claude-code)