### PR TITLE
feat(velero): add trust-bundle component for self-signed S3

### DIFF
--- a/docs/infra/velero.md
+++ b/docs/infra/velero.md
@@ -13,6 +13,10 @@ Anchors the work in [#111](https://github.com/stuttgart-things/flux/issues/111) 
 
 The base layer creates the `cloud-credentials` Secret via the `sthings-cluster` helper chart using substitution variables. To use ESO instead, enable the `components/external-secret/` kustomize Component and patch out the helper-chart HelmRelease — see the [README](https://github.com/stuttgart-things/flux/blob/main/infra/velero/README.md#2-external-secrets-operator-opt-in) for the patch.
 
+## Trust bundle for self-signed S3 endpoints
+
+For MinIO/S3 endpoints served with a private-CA certificate (Vault PKI etc.), enable the `components/trust-bundle/` Component. It mounts a trust-manager Bundle ConfigMap into the velero pod and sets `AWS_CA_BUNDLE` so the AWS Go SDK verifies the endpoint against it. The volume mount uses `optional: true` so the pod starts even before trust-manager has replicated the ConfigMap.
+
 ## Deployment
 
 ### GitRepository

--- a/infra/velero/README.md
+++ b/infra/velero/README.md
@@ -45,6 +45,25 @@ spec:
 
 Requires External Secrets Operator and a `ClusterSecretStore` already installed in the cluster.
 
+## Trust bundle for self-signed S3 endpoints
+
+If your MinIO/S3 endpoint is served with a certificate signed by a private CA (e.g. Vault PKI), enable the `components/trust-bundle/` kustomize Component. It mounts a trust-manager-published ConfigMap (default: `cluster-trust-bundle`, key `trust-bundle.pem`) into the velero pod and sets `AWS_CA_BUNDLE` so the AWS Go SDK verifies the endpoint against it.
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+spec:
+  path: ./infra/velero
+  components:
+    - ./components/trust-bundle
+  postBuild:
+    substitute:
+      VELERO_TRUST_BUNDLE_CONFIGMAP: cluster-trust-bundle
+      VELERO_TRUST_BUNDLE_KEY: trust-bundle.pem
+```
+
+The ConfigMap volume is mounted with `optional: true` so the velero pod can start even if trust-manager hasn't yet replicated the ConfigMap into the namespace.
+
 ## Required variables
 
 | Variable | Default | Description |
@@ -71,3 +90,6 @@ Requires External Secrets Operator and a `ClusterSecretStore` already installed 
 | `VELERO_ESO_ACCESS_KEY_PROPERTY` | `access_key` | KV property for access key (mode 2 only) |
 | `VELERO_ESO_SECRET_KEY_PROPERTY` | `secret_key` | KV property for secret key (mode 2 only) |
 | `VELERO_ESO_REFRESH_INTERVAL` | `1h` | ESO refresh interval (mode 2 only) |
+| `VELERO_TRUST_BUNDLE_CONFIGMAP` | `cluster-trust-bundle` | trust-manager ConfigMap to mount (trust-bundle Component only) |
+| `VELERO_TRUST_BUNDLE_KEY` | `trust-bundle.pem` | Key inside the ConfigMap (trust-bundle Component only) |
+| `VELERO_TRUST_BUNDLE_MOUNT_PATH` | `/etc/ssl/custom` | Mount path inside the velero pod (trust-bundle Component only) |

--- a/infra/velero/components/trust-bundle/kustomization.yaml
+++ b/infra/velero/components/trust-bundle/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  # Mount the trust-manager Bundle ConfigMap into the velero pod and point
+  # the AWS SDK at it via AWS_CA_BUNDLE so MinIO endpoints signed by the
+  # cluster/Vault PKI are trusted.
+  - target:
+      kind: HelmRelease
+      name: velero
+    patch: |
+      - op: add
+        path: /spec/values/extraVolumes
+        value:
+          - name: trust-bundle
+            configMap:
+              name: ${VELERO_TRUST_BUNDLE_CONFIGMAP:-cluster-trust-bundle}
+              optional: true
+      - op: add
+        path: /spec/values/extraVolumeMounts
+        value:
+          - name: trust-bundle
+            mountPath: ${VELERO_TRUST_BUNDLE_MOUNT_PATH:-/etc/ssl/custom}
+            readOnly: true
+      - op: add
+        path: /spec/values/configuration/extraEnvVars
+        value:
+          AWS_CA_BUNDLE: ${VELERO_TRUST_BUNDLE_MOUNT_PATH:-/etc/ssl/custom}/${VELERO_TRUST_BUNDLE_KEY:-trust-bundle.pem}
+          SSL_CERT_FILE: ${VELERO_TRUST_BUNDLE_MOUNT_PATH:-/etc/ssl/custom}/${VELERO_TRUST_BUNDLE_KEY:-trust-bundle.pem}


### PR DESCRIPTION
## Summary

Adds `infra/velero/components/trust-bundle/` kustomize Component for clusters whose MinIO/S3 endpoint is served with a private-CA certificate (e.g. Vault PKI on platform-sthings).

- Patches the velero HelmRelease via JSON Patch to add `extraVolumes`/`extraVolumeMounts` (mounts the trust-manager-published \`cluster-trust-bundle\` ConfigMap) and `configuration.extraEnvVars` (`AWS_CA_BUNDLE`, `SSL_CERT_FILE`).
- ConfigMap volume is `optional: true` so the pod starts before trust-manager has replicated the bundle into the velero namespace.
- README and TechDocs page updated.

Unblocks the platform-sthings test deploy (S3 endpoint `artifacts.platform.sthings-vsphere.labul.sva.de` is signed by the cluster CA).

## Test plan

- [x] `kustomize build` of base + trust-bundle Component verified locally — `extraEnvVars` lands next to existing `configuration.backupStorageLocation` without disturbing it
- [ ] Wire into platform-sthings overlay via `apps-upstream` GitRepository (main branch) and confirm velero pod can list the MinIO bucket without TLS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)