### PR TITLE
fix(velero): use plain Secret instead of sthings-cluster helper

### DIFF
--- a/infra/velero/README.md
+++ b/infra/velero/README.md
@@ -10,7 +10,7 @@ Two mutually-exclusive ways to populate the `cloud-credentials` Secret consumed 
 
 ### 1. Substitution (default)
 
-The base `pre-release.yaml` uses the `sthings-cluster` helper chart to create the Secret from Flux `postBuild.substitute` values (`VELERO_S3_ACCESS_KEY`, `VELERO_S3_SECRET_KEY`). Pair with SOPS for the actual credential values:
+The base `pre-release.yaml` is a plain `Secret` manifest populated from Flux `postBuild.substitute` values (`VELERO_S3_ACCESS_KEY`, `VELERO_S3_SECRET_KEY`). Pair with SOPS for the actual credential values:
 
 ```yaml
 postBuild:
@@ -21,7 +21,7 @@ postBuild:
 
 ### 2. External Secrets Operator (opt-in)
 
-Use the kustomize Component at `components/external-secret/` to pull credentials from Vault via ESO instead. Enable it in your consumer Flux `Kustomization` overlay and patch out the `pre-release.yaml` resource so the two don't fight over `cloud-credentials`:
+Use the kustomize Component at `components/external-secret/` to pull credentials from Vault via ESO instead. Enable it in your consumer Flux `Kustomization` overlay and patch out the base `cloud-credentials` Secret so the two don't fight over it:
 
 ```yaml
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -32,14 +32,14 @@ spec:
     - ./components/external-secret
   patches:
     - target:
-        kind: HelmRelease
-        name: velero-credentials
+        kind: Secret
+        name: cloud-credentials
       patch: |
         $patch: delete
-        apiVersion: helm.toolkit.fluxcd.io/v2
-        kind: HelmRelease
+        apiVersion: v1
+        kind: Secret
         metadata:
-          name: velero-credentials
+          name: cloud-credentials
           namespace: velero
 ```
 
@@ -83,7 +83,6 @@ The ConfigMap volume is mounted with `optional: true` so the velero pod can star
 | `VELERO_DEPLOY_NODE_AGENT` | `false` | Deploy node-agent for filesystem backup (Kopia/Restic) |
 | `VELERO_METRICS_ENABLED` | `true` | Expose Prometheus metrics |
 | `VELERO_SERVICE_MONITOR_ENABLED` | `false` | Create a Prometheus ServiceMonitor |
-| `STHINGS_CLUSTER_VERSION` | `0.3.20` | sthings-cluster helper chart version (mode 1 only) |
 | `VELERO_ESO_SECRET_STORE_NAME` | `vault-cluster` | ClusterSecretStore name (mode 2 only) |
 | `VELERO_ESO_SECRET_STORE_KIND` | `ClusterSecretStore` | Secret store kind (mode 2 only) |
 | `VELERO_ESO_SECRET_PATH` | `kv/data/velero/s3` | Vault KV path holding the S3 credentials (mode 2 only) |

--- a/infra/velero/pre-release.yaml
+++ b/infra/velero/pre-release.yaml
@@ -1,31 +1,12 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
+apiVersion: v1
+kind: Secret
 metadata:
-  name: velero-credentials
+  name: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
   namespace: ${VELERO_NAMESPACE:-velero}
-spec:
-  interval: 30m
-  chart:
-    spec:
-      chart: sthings-cluster
-      version: ${STHINGS_CLUSTER_VERSION:-0.3.20}
-      sourceRef:
-        kind: HelmRepository
-        name: stuttgart-things
-        namespace: ${VELERO_NAMESPACE:-velero}
-      interval: 12h
-  values:
-    customresources:
-      cloud-credentials:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
-          namespace: ${VELERO_NAMESPACE:-velero}
-        type: Opaque
-        stringData:
-          cloud: |
-            [default]
-            aws_access_key_id=${VELERO_S3_ACCESS_KEY}
-            aws_secret_access_key=${VELERO_S3_SECRET_KEY}
+type: Opaque
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id=${VELERO_S3_ACCESS_KEY}
+    aws_secret_access_key=${VELERO_S3_SECRET_KEY}

--- a/infra/velero/release.yaml
+++ b/infra/velero/release.yaml
@@ -5,9 +5,6 @@ metadata:
   name: velero
   namespace: ${VELERO_NAMESPACE:-velero}
 spec:
-  dependsOn:
-    - name: velero-credentials
-      namespace: ${VELERO_NAMESPACE:-velero}
   interval: 30m
   timeout: 10m
   chart:

--- a/infra/velero/requirements.yaml
+++ b/infra/velero/requirements.yaml
@@ -14,13 +14,3 @@ metadata:
 spec:
   interval: 1h
   url: https://vmware-tanzu.github.io/helm-charts
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: stuttgart-things
-  namespace: ${VELERO_NAMESPACE:-velero}
-spec:
-  type: oci
-  interval: 1h
-  url: oci://ghcr.io/stuttgart-things


### PR DESCRIPTION
## Summary

The base \`pre-release.yaml\` used the \`sthings-cluster\` helper chart to create the \`cloud-credentials\` Secret. The chart's \`customresources\` template wraps each entry in a \`spec:\` field — valid for the CRD-style resources every existing pre-release uses (Certificate, Bundle, ClusterIssuer) but invalid for a core \`Secret\`. Helm install failed on the platform-sthings test deploy:

\`\`\`
failed to create typed patch object (velero/cloud-credentials; /v1, Kind=Secret):
.spec: field not declared in schema
\`\`\`

Switch to a plain \`Secret\` manifest. Also drop the now-unused \`stuttgart-things\` HelmRepository and the \`release.yaml\` \`dependsOn\` on \`velero-credentials\`.

ESO opt-in patch target updated from \`HelmRelease/velero-credentials\` → \`Secret/cloud-credentials\`.

## Test plan

- [ ] Once merged, \`Flux reconcile\` on platform-sthings; \`HelmRelease/velero-credentials\` should be replaced by \`Secret/cloud-credentials\`
- [ ] \`velero\` pod becomes Ready
- [ ] \`velero backup-location get\` reports \`default\` BSL \`Available\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)