### PR TITLE
fix(velero): override CRD-install hook kubectl image to bitnamilegacy

### DIFF
--- a/infra/velero/README.md
+++ b/infra/velero/README.md
@@ -71,6 +71,8 @@ The ConfigMap volume is mounted with `optional: true` so the velero pod can star
 | `VELERO_NAMESPACE` | `velero` | Target namespace |
 | `VELERO_VERSION` | `9.0.0` | velero Helm chart version |
 | `VELERO_PLUGIN_AWS_VERSION` | `v1.13.0` | velero-plugin-for-aws image tag |
+| `VELERO_KUBECTL_IMAGE_REPOSITORY` | `docker.io/bitnamilegacy/kubectl` | kubectl image used by the chart's CRD-install hook (bitnami sunset their free namespace late 2025) |
+| `VELERO_KUBECTL_IMAGE_TAG` | `1.33.4` | kubectl image tag for the CRD-install hook |
 | `VELERO_BUCKET` | *(required)* | S3 bucket name |
 | `VELERO_S3_ENDPOINT` | *(required)* | S3 endpoint URL (MinIO URL for self-hosted) |
 | `VELERO_S3_REGION` | `minio` | S3 region (MinIO accepts any string) |

--- a/infra/velero/release.yaml
+++ b/infra/velero/release.yaml
@@ -55,3 +55,11 @@ spec:
     upgradeJob:
       enabled: false
     cleanUpCRDs: false
+    # The chart's upgradeCRDs pre-install hook needs a kubectl image.
+    # bitnami sunset their free Docker Hub catalogue in late 2025
+    # (docker.io/bitnami/kubectl has only `latest` and SHA tags now);
+    # working semver tags moved to bitnamilegacy.
+    kubectl:
+      image:
+        repository: ${VELERO_KUBECTL_IMAGE_REPOSITORY:-docker.io/bitnamilegacy/kubectl}
+        tag: ${VELERO_KUBECTL_IMAGE_TAG:-1.33.4}


### PR DESCRIPTION
## Summary

Chart's \`upgradeCRDs\` pre-install hook defaults to \`docker.io/bitnami/kubectl:1.35\`, which doesn't exist:

\`\`\`
Failed to pull image "docker.io/bitnami/kubectl:1.35":
docker.io/bitnami/kubectl:1.35: not found
\`\`\`

Bitnami sunset their free Docker Hub catalogue in late 2025 — \`docker.io/bitnami/kubectl\` now only publishes \`latest\` and SHA-tagged entries (verified by querying Docker Hub API). Working semver tags moved to \`docker.io/bitnamilegacy/kubectl\` (e.g. \`1.33.4\`).

Set \`kubectl.image.{repository,tag}\` explicitly, overridable via \`VELERO_KUBECTL_IMAGE_{REPOSITORY,TAG}\` substitution vars.

## Test plan

- [ ] Once merged, Flux reconcile on platform-sthings — velero pre-install Job should successfully pull \`bitnamilegacy/kubectl:1.33.4\` and complete
- [ ] velero pod Running, BSL Available

🤖 Generated with [Claude Code](https://claude.com/claude-code)