### PR TITLE
fix(velero): use literal cloud-credentials Secret name

### DIFF
--- a/infra/velero/README.md
+++ b/infra/velero/README.md
@@ -78,7 +78,6 @@ The ConfigMap volume is mounted with `optional: true` so the velero pod can star
 | `VELERO_S3_REGION` | `minio` | S3 region (MinIO accepts any string) |
 | `VELERO_S3_FORCE_PATH_STYLE` | `true` | Path-style URLs (required for MinIO) |
 | `VELERO_S3_INSECURE_SKIP_TLS_VERIFY` | `false` | Skip TLS verify on S3 endpoint |
-| `VELERO_CREDENTIALS_SECRET_NAME` | `cloud-credentials` | Secret consumed by Velero |
 | `VELERO_S3_ACCESS_KEY` | *(required in mode 1)* | MinIO access key |
 | `VELERO_S3_SECRET_KEY` | *(required in mode 1)* | MinIO secret key |
 | `VELERO_SNAPSHOTS_ENABLED` | `false` | Enable volume snapshots |

--- a/infra/velero/components/external-secret/external-secret.yaml
+++ b/infra/velero/components/external-secret/external-secret.yaml
@@ -10,7 +10,7 @@ spec:
     name: ${VELERO_ESO_SECRET_STORE_NAME:-vault-cluster}
     kind: ${VELERO_ESO_SECRET_STORE_KIND:-ClusterSecretStore}
   target:
-    name: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
+    name: cloud-credentials
     creationPolicy: Owner
     template:
       type: Opaque

--- a/infra/velero/pre-release.yaml
+++ b/infra/velero/pre-release.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
+  name: cloud-credentials
   namespace: ${VELERO_NAMESPACE:-velero}
 type: Opaque
 stringData:

--- a/infra/velero/release.yaml
+++ b/infra/velero/release.yaml
@@ -26,7 +26,7 @@ spec:
             mountPath: /target
     credentials:
       useSecret: true
-      existingSecret: ${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}
+      existingSecret: cloud-credentials
     configuration:
       backupStorageLocation:
         - name: default


### PR DESCRIPTION
## Summary

The \`VELERO_CREDENTIALS_SECRET_NAME\` substitution variable made the Secret's \`metadata.name\` a literal \`\${VELERO_CREDENTIALS_SECRET_NAME:-cloud-credentials}\` string at kustomize time — Flux substitution only runs *after* kustomize build. That broke consumer overlays trying to patch the Secret by name: kustomize matches patch targets against the pre-substitution name, so \`target: { kind: Secret, name: cloud-credentials }\` silently skipped, leaving the base's \`\${VELERO_S3_ACCESS_KEY}\` / \`\${VELERO_S3_SECRET_KEY}\` placeholders, which then substituted to empty.

Caught by the platform-sthings test deploy — the velero BSL went Unavailable with the AWS SDK falling back to EC2 IMDS credential discovery because the credentials file held empty access/secret keys.

The variable wasn't load-bearing (the chart's \`credentials.existingSecret\` also referenced it, so they were always coupled). Drop it and use the literal name \`cloud-credentials\` everywhere — base, ESO Component, README.

## Test plan

- [ ] Once merged + reconciled on platform-sthings: \`kubectl -n velero get secret cloud-credentials -o jsonpath='{.data.cloud}' | base64 -d\` shows real access/secret key values
- [ ] BSL \`default\` transitions Unavailable → Available

🤖 Generated with [Claude Code](https://claude.com/claude-code)