### PR TITLE
docs(velero): document ServiceMonitor CRD prerequisite

### DIFF
--- a/docs/infra/velero.md
+++ b/docs/infra/velero.md
@@ -17,6 +17,10 @@ The base layer creates the `cloud-credentials` Secret via the `sthings-cluster` 
 
 The base mounts the trust-manager-published `cluster-trust-bundle` ConfigMap into the velero pod at `/etc/ssl/custom` with `optional: true` — harmless when no ConfigMap is published. To activate it, set `VELERO_SSL_CERT_DIR=/etc/ssl/custom` so Go's `crypto/x509` reads the bundle instead of the system CA store. Empty default = system CAs. See the [README](https://github.com/stuttgart-things/flux/blob/main/infra/velero/README.md#trust-bundle-for-self-signed-s3-endpoints) for the trust-manager Bundle requirements.
 
+## ServiceMonitor prerequisite
+
+`VELERO_SERVICE_MONITOR_ENABLED=true` requires the `monitoring.coreos.com/v1` `ServiceMonitor` CRD — provided by [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) or a standalone prometheus-operator install. The standalone `prometheus` Helm chart does **not** ship the CRD; enabling the toggle without the operator present causes the Helm install to fail with `no matches for kind "ServiceMonitor"`. With no operator, leave the toggle off — the `/metrics` endpoint stays exposed on the velero Service and can be scraped via a static job.
+
 ## Deployment
 
 ### GitRepository

--- a/infra/velero/README.md
+++ b/infra/velero/README.md
@@ -139,6 +139,21 @@ When `VELERO_SSL_CERT_DIR` is unset (default empty), Go treats the env var as no
 
 > **Note:** `SSL_CERT_DIR` _replaces_ Go's default CA directory list — your trust-manager Bundle must include `useDefaultCAs: true` if you also need public CAs (e.g. for AWS S3 over the public internet).
 
+## ServiceMonitor (Prometheus scraping)
+
+Setting `VELERO_SERVICE_MONITOR_ENABLED=true` makes the chart render a `monitoring.coreos.com/v1` `ServiceMonitor` resource. That CRD is **not** part of the standalone `prometheus` Helm chart — it ships with [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) or a standalone install of the [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator).
+
+If the CRD is missing the Helm install will fail with:
+
+```
+no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
+```
+
+Workarounds:
+
+- **Have prometheus-operator** → set `VELERO_SERVICE_MONITOR_ENABLED=true` (default uses label `release: prometheus` for Prometheus discovery; override via the chart's `metrics.serviceMonitor.additionalLabels` if your operator selects differently).
+- **No operator, just want metrics** → leave `VELERO_SERVICE_MONITOR_ENABLED=false` (default). The `/metrics` endpoint is still exposed on the velero Service (port `8085`); scrape it with a static `prometheus.yml` job or a `kubernetes_sd_configs` scrape rule.
+
 ## Required variables
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary

Setting \`VELERO_SERVICE_MONITOR_ENABLED=true\` makes the chart render a \`monitoring.coreos.com/v1\` \`ServiceMonitor\`. That CRD is not part of the standalone \`prometheus\` Helm chart — it ships with [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) or a standalone prometheus-operator install.

Enabling the toggle without the CRD present causes the Helm install to fail with:

\`\`\`
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
\`\`\`

Add a ServiceMonitor section to \`infra/velero/README.md\` and \`docs/infra/velero.md\` documenting the prereq, the failure mode, and the no-operator workaround (leave the toggle off; \`/metrics\` endpoint is still exposed for static scrape configs).

Caught on platform-sthings deploy where the standalone \`prometheus\` chart is in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)