### PR TITLE
feat(kube-prometheus-stack): add observability stack component

### DIFF
--- a/infra/kube-prometheus-stack/README.md
+++ b/infra/kube-prometheus-stack/README.md
@@ -1,0 +1,144 @@
+# stuttgart-things/flux/kube-prometheus-stack
+
+Full observability stack — Prometheus + Alertmanager + Grafana + node-exporter
++ kube-state-metrics + prometheus-operator — from the
+[`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+chart.
+
+Replaces the standalone `infra/prometheus` component (see [Cutover](#cutover)).
+
+## Deployment
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kube-prometheus-stack
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 15m
+  sourceRef:
+    kind: GitRepository
+    name: flux-infra
+  path: ./infra/kube-prometheus-stack
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      KPS_NAMESPACE: monitoring
+      KPS_VERSION: "85.2.1"
+      KPS_PROMETHEUS_STORAGE_CLASS: nfs4-csi
+      KPS_PROMETHEUS_STORAGE_SIZE: 10Gi
+      KPS_PROMETHEUS_RETENTION: 15d
+      KPS_SCRAPE_INTERVAL: 60s
+      KPS_GRAFANA_ADMIN_PASSWORD: prom-operator
+      GATEWAY_NAME: platform-sthings-gateway
+      GATEWAY_NAMESPACE: default
+      HOSTNAME: grafana
+      DOMAIN: platform.sthings-vsphere.labul.sva.de
+EOF
+```
+
+Grafana is then reachable at `https://grafana.platform.sthings-vsphere.labul.sva.de`
+(login `admin` / `KPS_GRAFANA_ADMIN_PASSWORD`).
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `KPS_NAMESPACE` | `monitoring` | Target namespace |
+| `KPS_VERSION` | `85.2.1` | Helm chart version |
+| `KPS_PROMETHEUS_STORAGE_CLASS` | `nfs4-csi` | StorageClass for the Prometheus TSDB PVC |
+| `KPS_PROMETHEUS_STORAGE_SIZE` | `10Gi` | Prometheus PVC size |
+| `KPS_PROMETHEUS_RETENTION` | `15d` | Metrics retention period |
+| `KPS_SCRAPE_INTERVAL` | `60s` | Global scrape + rule evaluation interval |
+| `KPS_GRAFANA_ADMIN_PASSWORD` | `prom-operator` | Grafana admin password (see note below) |
+| `GATEWAY_NAME` | *(required)* | Cilium Gateway resource name for the HTTPRoute |
+| `GATEWAY_NAMESPACE` | `default` | Namespace of the Gateway resource |
+| `HOSTNAME` | *(required)* | Hostname prefix for the Grafana HTTPRoute |
+| `DOMAIN` | *(required)* | Domain suffix for the Grafana HTTPRoute |
+
+## Design notes — keeping it lean
+
+- **One replica each** for Prometheus, Alertmanager, Grafana and the operator.
+- **`scrapeInterval: 60s`** (chart default is 30s) — roughly halves scrape CPU
+  and TSDB write volume.
+- **Grafana is ephemeral** (`persistence.enabled: false`) — the bundled
+  dashboards are re-provisioned from ConfigMaps on every start, so no PVC is
+  needed.
+- **Alertmanager is ephemeral** (emptyDir) — silences do not survive a restart.
+- **Control-plane scrape jobs disabled** (`kubeProxy`, `kubeControllerManager`,
+  `kubeScheduler`, `kubeEtcd`) — Cilium runs kube-proxy-replacement and RKE2
+  binds control-plane metrics to localhost, so these would only generate
+  `TargetDown` noise.
+- Modest CPU/memory **requests + limits** on every component. Total resource
+  *requests* are ≈ 200m CPU / ≈ 800Mi memory across the cluster.
+
+### Pods this deploys
+
+| Component | Pods |
+|---|---|
+| prometheus-operator | 1 |
+| Prometheus | 1 (StatefulSet) |
+| Alertmanager | 1 (StatefulSet) |
+| Grafana | 1 |
+| kube-state-metrics | 1 |
+| node-exporter | 1 per node (DaemonSet) |
+
+On a 4-node cluster: **9 pods**. The replaced `infra/prometheus` ran 6
+(prometheus-server + kube-state-metrics + 4× node-exporter), so the net
+addition is 3 pods (operator, Alertmanager, Grafana) for full dashboards +
+alerting.
+
+## Predefined dashboards
+
+`grafana.defaultDashboardsEnabled: true` ships the standard set: Kubernetes
+Compute Resources (Cluster / Namespace / Node / Pod / Workload), Node Exporter
+(Nodes / USE Method), kube-apiserver, Kubelet, Persistent Volumes, CoreDNS,
+Prometheus and Alertmanager overviews. The Prometheus datasource is
+auto-provisioned. Add more dashboards by creating a ConfigMap labelled
+`grafana_dashboard: "1"` in the namespace — the Grafana sidecar imports it.
+
+## Alerting
+
+The chart's `defaultRules` are enabled, so alerts like `KubePodCrashLooping`,
+`TargetDown` and `KubePersistentVolumeFillingUp` evaluate out of the box.
+**Alertmanager currently routes to a null receiver** — wire real receivers
+(Slack / email / webhook) by adding an `alertmanager.config` block to
+`release.yaml`.
+
+## Cutover
+
+`kube-prometheus-stack` **cannot run alongside** the old `infra/prometheus`:
+both deploy a node-exporter DaemonSet that binds host port `9100`, and both
+manage a `prometheus-community` `HelmRepository` in `monitoring`. Cut over in
+order:
+
+1. Merge this component.
+2. Remove the **old** `prometheus` Flux Kustomization (with `prune: true` it
+   tears down the old release):
+   ```bash
+   flux delete kustomization prometheus -n flux-system
+   ```
+3. Apply the `kube-prometheus-stack` Kustomization (see [Deployment](#deployment)).
+4. **Repoint Headlamp** at the new Prometheus service. The old service was
+   `prometheus-server.monitoring.svc:80`; the new one is
+   `kube-prometheus-stack-prometheus.monitoring.svc:9090`.
+5. Once verified, delete the `infra/prometheus` directory from this repo.
+
+## CRD note
+
+The prometheus-operator CRDs are large. If a chart upgrade ever fails with
+`metadata.annotations: Too long`, install the CRDs via a dedicated Flux
+Kustomization (raw manifests from the chart's `charts/crds`) and set
+`crds.enabled: false` in `release.yaml`.
+
+## Components
+
+- **requirements.yaml** — Namespace + `prometheus-community` HelmRepository
+- **release.yaml** — `kube-prometheus-stack` HelmRelease (tuned values)
+- **httproute.yaml** — Gateway API HTTPRoute exposing Grafana

--- a/infra/kube-prometheus-stack/httproute.yaml
+++ b/infra/kube-prometheus-stack/httproute.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  namespace: ${KPS_NAMESPACE:-monitoring}
+spec:
+  parentRefs:
+    - name: ${GATEWAY_NAME}
+      namespace: ${GATEWAY_NAMESPACE:-default}
+  hostnames:
+    - "${HOSTNAME}.${DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kube-prometheus-stack-grafana
+          port: 80

--- a/infra/kube-prometheus-stack/kustomization.yaml
+++ b/infra/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml
+  - httproute.yaml

--- a/infra/kube-prometheus-stack/release.yaml
+++ b/infra/kube-prometheus-stack/release.yaml
@@ -1,0 +1,147 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: ${KPS_NAMESPACE:-monitoring}
+spec:
+  interval: 30m
+  timeout: 15m
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: ${KPS_VERSION:-85.2.1}
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: ${KPS_NAMESPACE:-monitoring}
+      interval: 12h
+  values:
+    # CRDs (prometheus-operator) are rendered as normal templates by the
+    # chart's crds subchart. If a future upgrade fails with "metadata.
+    # annotations: Too long", install the CRDs via a separate Kustomization
+    # and set crds.enabled=false here -- see README.
+    crds:
+      enabled: true
+
+    # Keep the chart's curated default alert rules -- these are what
+    # Alertmanager fires on (e.g. KubePodCrashLooping would have caught
+    # the snapshot-controller 11k-restart loop on day one).
+    defaultRules:
+      create: true
+
+    # ---- Control-plane scrape jobs: disabled ----
+    # Cilium runs in kube-proxy-replacement mode (no kube-proxy DaemonSet),
+    # and RKE2 static-pod control-plane components bind their metrics
+    # endpoints to localhost. The default ServiceMonitors would only
+    # produce permanent "TargetDown" noise. Node, workload, kubelet and
+    # kube-apiserver metrics are unaffected and still scraped.
+    kubeProxy:
+      enabled: false
+    kubeControllerManager:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeEtcd:
+      enabled: false
+
+    # ---- prometheus-operator ----
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 20m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+
+    # ---- Prometheus ----
+    prometheus:
+      prometheusSpec:
+        replicas: 1
+        # 60s (vs the chart default 30s) roughly halves scrape CPU and
+        # TSDB write volume -- the main "performance cost" lever.
+        scrapeInterval: ${KPS_SCRAPE_INTERVAL:-60s}
+        evaluationInterval: ${KPS_SCRAPE_INTERVAL:-60s}
+        retention: ${KPS_PROMETHEUS_RETENTION:-15d}
+        # Discover ServiceMonitors / PodMonitors / Rules from ALL
+        # namespaces, not just objects carrying this release's label.
+        serviceMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1536Mi
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ${KPS_PROMETHEUS_STORAGE_CLASS:-nfs4-csi}
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: ${KPS_PROMETHEUS_STORAGE_SIZE:-10Gi}
+
+    # ---- Alertmanager ----
+    # Enabled so alert rules actually route somewhere. Receivers (Slack /
+    # email / webhook) are wired up later via alertmanager.config.
+    alertmanager:
+      enabled: true
+      alertmanagerSpec:
+        replicas: 1
+        retention: 120h
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+      # No storage block -> emptyDir. Silences do not survive a restart,
+      # which is acceptable for this cluster.
+
+    # ---- Grafana ----
+    # Ephemeral: no PVC. The bundled dashboards are provisioned from
+    # ConfigMaps by the sidecar on every start, so nothing is lost on
+    # restart. Manual in-UI dashboard/user edits would not persist.
+    grafana:
+      enabled: true
+      replicas: 1
+      adminPassword: ${KPS_GRAFANA_ADMIN_PASSWORD:-prom-operator}
+      # Bundled Kubernetes / Node Exporter / Prometheus dashboards.
+      defaultDashboardsEnabled: true
+      defaultDashboardsTimezone: browser
+      persistence:
+        enabled: false
+      # Routed via Gateway API HTTPRoute (httproute.yaml), not chart Ingress.
+      ingress:
+        enabled: false
+      grafana.ini:
+        server:
+          root_url: "https://${HOSTNAME}.${DOMAIN}"
+      resources:
+        requests:
+          cpu: 20m
+          memory: 64Mi
+        limits:
+          memory: 192Mi
+
+    # ---- node-exporter (DaemonSet, one pod per node) ----
+    prometheus-node-exporter:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 24Mi
+        limits:
+          memory: 64Mi
+
+    # ---- kube-state-metrics ----
+    kube-state-metrics:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 128Mi

--- a/infra/kube-prometheus-stack/requirements.yaml
+++ b/infra/kube-prometheus-stack/requirements.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${KPS_NAMESPACE:-monitoring}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: ${KPS_NAMESPACE:-monitoring}
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
## What

Adds `infra/kube-prometheus-stack` — a full observability stack (Prometheus + Alertmanager + Grafana + node-exporter + kube-state-metrics + prometheus-operator) from the `kube-prometheus-stack` Helm chart `85.2.1`. Intended to **replace** the standalone `infra/prometheus` component.

## Why

Clusters running `infra/prometheus` had metrics but no Alertmanager and no Grafana — alert rules evaluated but nothing notified, and there were no dashboards.

## Design

- **Low overhead:** single replicas, `scrapeInterval: 60s`, modest requests/limits on every component, RKE2/Cilium control-plane scrape jobs (`kubeProxy`/`kubeControllerManager`/`kubeScheduler`/`kubeEtcd`) disabled to avoid `TargetDown` noise.
- **Grafana:** ephemeral (no PVC — bundled dashboards re-provision from ConfigMaps), exposed via Gateway API `HTTPRoute`, chart Ingress disabled.
- **Alertmanager:** enabled (null receiver — real receivers wired per-cluster later).
- Follows the standard component anatomy (`requirements`/`release`/`httproute`/`kustomization` + README) with `${VAR:-default}` substitution.

See `infra/kube-prometheus-stack/README.md` for variables and the cutover procedure from `infra/prometheus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)