### PR TITLE
feat(kube-prometheus-stack): route warning|critical alerts to MS Teams

### DIFF
--- a/infra/kube-prometheus-stack/README.md
+++ b/infra/kube-prometheus-stack/README.md
@@ -107,9 +107,19 @@ auto-provisioned. Add more dashboards by creating a ConfigMap labelled
 
 The chart's `defaultRules` are enabled, so alerts like `KubePodCrashLooping`,
 `TargetDown` and `KubePersistentVolumeFillingUp` evaluate out of the box.
-**Alertmanager currently routes to a null receiver** — wire real receivers
-(Slack / email / webhook) by adding an `alertmanager.config` block to
-`release.yaml`.
+
+Alertmanager routes `warning|critical` alerts to a **Microsoft Teams**
+channel via the native `msteamsv2` receiver; `info` alerts and the
+always-on `Watchdog` fall through to the `null` receiver and are dropped.
+
+**Prerequisite:** the cluster must provide a Secret named
+`alertmanager-msteams` in the release namespace with key `webhook-url`
+(a Teams *Workflows* "Post to a channel when a webhook request is
+received" URL). It is mounted by the operator at
+`/etc/alertmanager/secrets/alertmanager-msteams/webhook-url` and read via
+`webhook_url_file`, so the URL never lands in git or the HelmRelease
+values. Store it SOPS-encrypted. To add Slack/email, extend
+`alertmanager.config.receivers` in `release.yaml`.
 
 ## Cutover
 

--- a/infra/kube-prometheus-stack/release.yaml
+++ b/infra/kube-prometheus-stack/release.yaml
@@ -86,13 +86,19 @@ spec:
                   storage: ${KPS_PROMETHEUS_STORAGE_SIZE:-10Gi}
 
     # ---- Alertmanager ----
-    # Enabled so alert rules actually route somewhere. Receivers (Slack /
-    # email / webhook) are wired up later via alertmanager.config.
+    # Routes warning|critical alerts to an MS Teams channel via the
+    # native msteamsv2 receiver. info-level alerts and the always-on
+    # Watchdog fall through to the null receiver and are dropped.
     alertmanager:
       enabled: true
       alertmanagerSpec:
         replicas: 1
         retention: 120h
+        # prometheus-operator mounts this Secret at
+        # /etc/alertmanager/secrets/alertmanager-msteams/ — the cluster
+        # must provide it (key: webhook-url = Teams workflow webhook).
+        secrets:
+          - alertmanager-msteams
         resources:
           requests:
             cpu: 10m
@@ -101,6 +107,33 @@ spec:
             memory: 128Mi
       # No storage block -> emptyDir. Silences do not survive a restart,
       # which is acceptable for this cluster.
+      config:
+        route:
+          receiver: 'null'
+          group_by: ['namespace', 'alertname']
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 4h
+          routes:
+            - receiver: msteams
+              matchers:
+                - severity =~ "warning|critical"
+        receivers:
+          - name: 'null'
+          - name: msteams
+            msteamsv2_configs:
+              # URL kept out of git/values — read from the mounted secret.
+              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-msteams/webhook-url
+                send_resolved: true
+        inhibit_rules:
+          - source_matchers: ['severity = "critical"']
+            target_matchers: ['severity =~ "warning|info"']
+            equal: ['namespace', 'alertname']
+          - source_matchers: ['severity = "warning"']
+            target_matchers: ['severity = "info"']
+            equal: ['namespace', 'alertname']
+        templates:
+          - /etc/alertmanager/config/*.tmpl
 
     # ---- Grafana ----
     # Ephemeral: no PVC. The bundled dashboards are provisioned from
@@ -121,15 +154,15 @@ spec:
       grafana.ini:
         server:
           root_url: "https://${HOSTNAME}.${DOMAIN}"
-      # Grafana's baseline (with the bundled dashboard set loaded) sits
-      # around 250-350Mi; the limit must clear that or the container is
-      # OOMKilled. Request stays modest so scheduling overhead is low.
+      # Observed baseline with the bundled dashboard set is ~400-450Mi;
+      # 768Mi limit leaves headroom for query/render load. Request stays
+      # modest so scheduling overhead is low.
       resources:
         requests:
           cpu: 20m
           memory: 128Mi
         limits:
-          memory: 512Mi
+          memory: 768Mi
 
     # ---- node-exporter (DaemonSet, one pod per node) ----
     prometheus-node-exporter:


### PR DESCRIPTION
## What

Wires Alertmanager to a **Microsoft Teams** channel and bumps the Grafana memory limit.

### Alerting
- Native `msteamsv2_configs` receiver — `warning|critical` alerts → Teams channel; `info` + the always-on `Watchdog` → `null` (dropped)
- Webhook URL read via `webhook_url_file` from a mounted Secret (`alertmanager-msteams`, key `webhook-url`) — the URL never enters git or the HelmRelease values. The cluster provides that Secret SOPS-encrypted.
- Adds the standard `severity` inhibit rules (critical suppresses warning/info for the same alert)

### Grafana
- `limits.memory` 512Mi → **768Mi** — observed baseline with the bundled dashboard set is ~400–450Mi; 512Mi left little headroom for query/render load.

## Prerequisite

Consumers must provide a Secret `alertmanager-msteams` (key `webhook-url`) in the release namespace — documented in the component README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)