### PR TITLE
feat(prometheus-msteams): add Teams proxy, route Alertmanager via it

### DIFF
--- a/infra/kube-prometheus-stack/README.md
+++ b/infra/kube-prometheus-stack/README.md
@@ -108,18 +108,18 @@ auto-provisioned. Add more dashboards by creating a ConfigMap labelled
 The chart's `defaultRules` are enabled, so alerts like `KubePodCrashLooping`,
 `TargetDown` and `KubePersistentVolumeFillingUp` evaluate out of the box.
 
-Alertmanager routes `warning|critical` alerts to a **Microsoft Teams**
-channel via the native `msteamsv2` receiver; `info` alerts and the
-always-on `Watchdog` fall through to the `null` receiver and are dropped.
+Alertmanager routes `warning|critical` alerts to **Microsoft Teams**;
+`info` alerts and the always-on `Watchdog` fall through to the `null`
+receiver and are dropped.
 
-**Prerequisite:** the cluster must provide a Secret named
-`alertmanager-msteams` in the release namespace with key `webhook-url`
-(a Teams *Workflows* "Post to a channel when a webhook request is
-received" URL). It is mounted by the operator at
-`/etc/alertmanager/secrets/alertmanager-msteams/webhook-url` and read via
-`webhook_url_file`, so the URL never lands in git or the HelmRelease
-values. Store it SOPS-encrypted. To add Slack/email, extend
-`alertmanager.config.receivers` in `release.yaml`.
+Delivery goes through the **`prometheus-msteams`** proxy (separate
+component) via a generic `webhook_configs` pointing at
+`http://prometheus-msteams.<ns>.svc.cluster.local:2000/alertmanager`. The
+proxy formats the Teams Adaptive Card, so the Teams webhook URL lives
+with that component, not here. See `infra/prometheus-msteams`.
+
+To add Slack/email, extend `alertmanager.config.receivers` in
+`release.yaml`.
 
 ## Cutover
 

--- a/infra/kube-prometheus-stack/release.yaml
+++ b/infra/kube-prometheus-stack/release.yaml
@@ -86,19 +86,15 @@ spec:
                   storage: ${KPS_PROMETHEUS_STORAGE_SIZE:-10Gi}
 
     # ---- Alertmanager ----
-    # Routes warning|critical alerts to an MS Teams channel via the
-    # native msteamsv2 receiver. info-level alerts and the always-on
+    # Routes warning|critical alerts to MS Teams via the in-cluster
+    # prometheus-msteams proxy (generic webhook_configs); the proxy
+    # formats the Adaptive Card. info-level alerts and the always-on
     # Watchdog fall through to the null receiver and are dropped.
     alertmanager:
       enabled: true
       alertmanagerSpec:
         replicas: 1
         retention: 120h
-        # prometheus-operator mounts this Secret at
-        # /etc/alertmanager/secrets/alertmanager-msteams/ — the cluster
-        # must provide it (key: webhook-url = Teams workflow webhook).
-        secrets:
-          - alertmanager-msteams
         resources:
           requests:
             cpu: 10m
@@ -121,9 +117,11 @@ spec:
         receivers:
           - name: 'null'
           - name: msteams
-            msteamsv2_configs:
-              # URL kept out of git/values — read from the mounted secret.
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-msteams/webhook-url
+            webhook_configs:
+              # Delivered via the in-cluster prometheus-msteams proxy,
+              # which converts this to a Teams Adaptive Card. /alertmanager
+              # is the proxy connector name.
+              - url: http://prometheus-msteams.${KPS_NAMESPACE:-monitoring}.svc.cluster.local:2000/alertmanager
                 send_resolved: true
         inhibit_rules:
           - source_matchers: ['severity = "critical"']

--- a/infra/prometheus-msteams/README.md
+++ b/infra/prometheus-msteams/README.md
@@ -1,0 +1,80 @@
+# stuttgart-things/flux/prometheus-msteams
+
+[`stakater/prometheus-msteams`](https://github.com/stakater/prometheus-msteams)
+— a small proxy that converts Alertmanager webhook notifications into
+Microsoft Teams Adaptive Cards and posts them to a Teams **Power Automate
+Workflow** webhook.
+
+## Why
+
+Alertmanager's native `msteamsv2` receiver sends a flat `{title,text}`
+payload that a stock Teams Workflow cannot render (`cards.unsupported`) —
+it needs the Workflow to be hand-edited in the Power Automate GUI, which
+is not reproducible. This proxy does the Adaptive Card formatting itself
+(`workflowWebhook: true`), from a Git-managed template, so the Teams
+Workflow can stay a stock "post the received card" flow.
+
+```
+Alertmanager --webhook_configs--> prometheus-msteams --> Teams Workflow
+```
+
+## Deployment
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: prometheus-msteams
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-infra
+  path: ./infra/prometheus-msteams
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      PROMETHEUS_MSTEAMS_NAMESPACE: monitoring
+      PROMETHEUS_MSTEAMS_VERSION: v1.0.2
+    substituteFrom:
+      - kind: Secret
+        name: prometheus-msteams-webhook
+EOF
+```
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PROMETHEUS_MSTEAMS_NAMESPACE` | `monitoring` | Target namespace |
+| `PROMETHEUS_MSTEAMS_VERSION` | `v1.0.2` | Git tag of the chart source |
+| `MSTEAMS_WEBHOOK_URL` | *(required, from Secret)* | Teams Power Automate webhook URL |
+
+**`MSTEAMS_WEBHOOK_URL`** must come from a SOPS-encrypted Secret consumed
+via the Kustomization's `postBuild.substituteFrom` — it is never committed
+in plain text.
+
+## Wiring Alertmanager
+
+The `kube-prometheus-stack` component routes its `msteams` receiver here:
+
+```yaml
+receivers:
+  - name: msteams
+    webhook_configs:
+      - url: http://prometheus-msteams.monitoring.svc.cluster.local:2000/alertmanager
+        send_resolved: true
+```
+
+The connector name (`alertmanager`) is the request path the proxy serves.
+
+## Components
+
+- **requirements.yaml** — Namespace + `GitRepository` chart source
+- **release.yaml** — `prometheus-msteams` HelmRelease (chart sourced from Git)

--- a/infra/prometheus-msteams/kustomization.yaml
+++ b/infra/prometheus-msteams/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml

--- a/infra/prometheus-msteams/release.yaml
+++ b/infra/prometheus-msteams/release.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-msteams
+  namespace: ${PROMETHEUS_MSTEAMS_NAMESPACE:-monitoring}
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: chart/prometheus-msteams
+      sourceRef:
+        kind: GitRepository
+        name: prometheus-msteams
+        namespace: ${PROMETHEUS_MSTEAMS_NAMESPACE:-monitoring}
+      interval: 12h
+  values:
+    replicaCount: 1
+    image:
+      repository: ghcr.io/stakater/public/prometheus-msteams
+      pullPolicy: IfNotPresent
+    # Power Automate Workflow webhook mode: prometheus-msteams formats the
+    # Teams Adaptive Card itself, so a stock "webhook request received"
+    # flow can post it directly -- no per-flow GUI customisation needed.
+    workflowWebhook: true
+    # Alertmanager posts to http://prometheus-msteams:2000/alertmanager.
+    # ${MSTEAMS_WEBHOOK_URL} is injected by the consuming Flux Kustomization
+    # via postBuild substituteFrom a Secret, so the URL never enters git.
+    connectors:
+      - alertmanager: '${MSTEAMS_WEBHOOK_URL}'
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi

--- a/infra/prometheus-msteams/requirements.yaml
+++ b/infra/prometheus-msteams/requirements.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${PROMETHEUS_MSTEAMS_NAMESPACE:-monitoring}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+# The stakater/prometheus-msteams chart is not published to a Helm
+# registry, so the chart is sourced straight from the Git repo at a
+# pinned tag; the HelmRelease points spec.chart at the in-repo path.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: prometheus-msteams
+  namespace: ${PROMETHEUS_MSTEAMS_NAMESPACE:-monitoring}
+spec:
+  interval: 24h
+  url: https://github.com/stakater/prometheus-msteams
+  ref:
+    tag: ${PROMETHEUS_MSTEAMS_VERSION:-v1.0.2}


### PR DESCRIPTION
## What

Adds the **`prometheus-msteams`** proxy component and rewires `kube-prometheus-stack` Alertmanager to deliver Teams alerts through it.

### New component `infra/prometheus-msteams`
- [`stakater/prometheus-msteams`](https://github.com/stakater/prometheus-msteams) — chart sourced from its Git repo at tag `v1.0.2` (not published to a Helm registry), `workflowWebhook: true`
- Converts Alertmanager webhook notifications → Teams Adaptive Cards → Power Automate Workflow webhook
- Teams webhook URL injected via `postBuild.substituteFrom` a Secret — never in git

### `kube-prometheus-stack` change
- `msteams` receiver: `msteamsv2_configs` (webhook_url_file) → `webhook_configs` → `http://prometheus-msteams…:2000/alertmanager`
- Drops the `alertmanagerSpec.secrets` mount — no longer needed

## Why

Alertmanager's native `msteamsv2` sends a flat `{title,text}` payload that a stock Teams Workflow can't render (`cards.unsupported`) without hand-editing the flow in the Power Automate GUI — not reproducible. The proxy does the Adaptive Card formatting from a Git-managed template, so the Teams flow stays stock.

## Prerequisite

Consumer provides Secret `prometheus-msteams-webhook` with key `MSTEAMS_WEBHOOK_URL` (documented in `infra/prometheus-msteams/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)