### PR TITLE
feat(homerun2): land notification-catcher + route Alertmanager through it

### DIFF
--- a/apps/homerun2/components/notification-catcher/README.md
+++ b/apps/homerun2/components/notification-catcher/README.md
@@ -1,0 +1,54 @@
+# homerun2/notification-catcher
+
+Outbound dispatcher — reads the `alerts` Redis stream and posts each message to Microsoft Teams (and any other configured webhook sink). Replacement for the in-cluster `prometheus-msteams` proxy: the Adaptive Card formatting and routing logic live in version-controlled Go code (see [`homerun2-notification-catcher`](https://github.com/stuttgart-things/homerun2-notification-catcher)).
+
+Pure consumer — no Service, no Ingress, no HTTPRoute.
+
+## Pipeline
+
+```
+Alertmanager ─▶ omni-pitcher /pitch/grafana ─▶ Redis stream "alerts"
+                                                     │
+                                          notification-catcher
+                                                     │
+                                                ▶ MS Teams
+```
+
+## Pattern
+
+OCIRepository + Flux Kustomization
+
+- **Source:** `oci://ghcr.io/stuttgart-things/homerun2-notification-catcher-kustomize`
+- **Image:** `ghcr.io/stuttgart-things/homerun2-notification-catcher`
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `HOMERUN2_NAMESPACE` | `homerun2` | Target namespace |
+| `HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION` | `v1.2.0` | OCI kustomize artifact version |
+| `HOMERUN2_NOTIFICATION_CATCHER_VERSION` | `v1.2.0` | Container image tag |
+| `HOMERUN2_REDIS_PASSWORD_B64` | *(required)* | Base64-encoded Redis password |
+| `TEAMS_WEBHOOK_URL` | *(required)* | Power Automate webhook URL for the destination Teams channel |
+
+`TEAMS_WEBHOOK_URL` must be supplied via the parent stack's `substituteFrom: homerun2-flux-secrets`.
+
+## Customizations
+
+- Sets the container image tag to `HOMERUN2_NOTIFICATION_CATCHER_VERSION`.
+- Patches the Redis password Secret with the cluster's `HOMERUN2_REDIS_PASSWORD_B64`.
+- Patches the env ConfigMap to point at `redis-stack.<namespace>.svc.cluster.local:6379`.
+- Patches the output-secrets Secret with `TEAMS_WEBHOOK_URL`.
+
+## Routing config
+
+The catcher reads `/etc/notification-catcher/config.yaml` (a ConfigMap mounted by the kustomize base) at startup. Webhook URLs in that YAML are written as `${TEAMS_WEBHOOK_URL}` placeholders — resolved at runtime against the env var that comes from this Secret patch. The real URL never lands in plaintext in the ConfigMap. See [`homerun2-notification-catcher/docs/deployment.md`](https://github.com/stuttgart-things/homerun2-notification-catcher/blob/main/docs/deployment.md) for the two-layer secret design.
+
+## Adding more outputs
+
+To wire in a new sink that needs a secret env var (PagerDuty, Slack, …):
+
+1. Extend the kustomize-base profile in `homerun2-notification-catcher/tests/kcl-deploy-profile.yaml` with the additional `outputSecrets` key and the YAML output stanza.
+2. Add the secret value to `homerun2-flux-secrets` (SOPS-encrypted) in the cluster repo.
+3. Add a patch here mapping the new key into the `<name>-secrets` Secret stringData (or extend the existing patch).
+4. Cut a new release of `homerun2-notification-catcher`; bump `HOMERUN2_NOTIFICATION_CATCHER_VERSION` here.

--- a/apps/homerun2/components/notification-catcher/kustomization.yaml
+++ b/apps/homerun2/components/notification-catcher/kustomization.yaml
@@ -4,5 +4,3 @@ kind: Component
 resources:
   - requirements.yaml
   - release.yaml
-  - httproute.yaml
-  - routes-configmap.yaml

--- a/apps/homerun2/components/notification-catcher/release.yaml
+++ b/apps/homerun2/components/notification-catcher/release.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homerun2-notification-catcher
+  namespace: ${HOMERUN2_NAMESPACE:-homerun2}
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: OCIRepository
+    name: homerun2-notification-catcher-kustomize
+  prune: true
+  wait: true
+  targetNamespace: ${HOMERUN2_NAMESPACE:-homerun2}
+  patches:
+    # Container image tag — pinned via the cluster's substitution Secret.
+    - target:
+        kind: Deployment
+        name: homerun2-notification-catcher
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: homerun2-notification-catcher
+        spec:
+          template:
+            spec:
+              containers:
+                - name: homerun2-notification-catcher
+                  image: ghcr.io/stuttgart-things/homerun2-notification-catcher:${HOMERUN2_NOTIFICATION_CATCHER_VERSION:-v1.2.0}
+
+    # Redis password — same SOPS-backed secret value the rest of homerun2 uses.
+    - target:
+        kind: Secret
+        name: homerun2-notification-catcher-redis
+      patch: |
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: homerun2-notification-catcher-redis
+        data:
+          password: ${HOMERUN2_REDIS_PASSWORD_B64}
+
+    # Redis connection — point at the co-deployed redis-stack rather than the
+    # KCL default. (The kustomize base already defaults to redis-stack.<ns>
+    # but we set it explicitly to mirror the core-catcher / omni-pitcher
+    # components and to make the namespace override visible here.)
+    - target:
+        kind: ConfigMap
+        name: homerun2-notification-catcher-env
+      patch: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: homerun2-notification-catcher-env
+        data:
+          REDIS_ADDR: redis-stack.${HOMERUN2_NAMESPACE:-homerun2}.svc.cluster.local
+          REDIS_PORT: "6379"
+
+    # Output secrets — webhook URLs for each Notifier the catcher dispatches
+    # to. The KCL base emits placeholders; Flux substituteFrom on the
+    # parent homerun2 stack rewrites ${TEAMS_WEBHOOK_URL} from the cluster's
+    # homerun2-flux-secrets Secret. If TEAMS_WEBHOOK_URL is not provided
+    # by substituteFrom, the catcher fails startup (silent misconfig is
+    # the worst failure mode for a dispatch service).
+    - target:
+        kind: Secret
+        name: homerun2-notification-catcher-secrets
+      patch: |
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: homerun2-notification-catcher-secrets
+        stringData:
+          TEAMS_WEBHOOK_URL: ${TEAMS_WEBHOOK_URL}

--- a/apps/homerun2/components/notification-catcher/requirements.yaml
+++ b/apps/homerun2/components/notification-catcher/requirements.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/${FLUX_SOURCE_API_VERSION:-v1}
+kind: OCIRepository
+metadata:
+  name: homerun2-notification-catcher-kustomize
+  namespace: ${HOMERUN2_NAMESPACE:-homerun2}
+spec:
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things/homerun2-notification-catcher-kustomize
+  ref:
+    tag: ${HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION:-v1.2.0}

--- a/apps/homerun2/components/omni-pitcher/release.yaml
+++ b/apps/homerun2/components/omni-pitcher/release.yaml
@@ -81,3 +81,33 @@ spec:
                       value: redis-stack.${HOMERUN2_NAMESPACE:-homerun2}.svc.cluster.local
                     - name: REDIS_PORT
                       value: "6379"
+    # Mount the routing config (./routes-configmap.yaml) into the pitcher
+    # and point ROUTES_CONFIG at it so /pitch/grafana traffic lands on the
+    # `alerts` stream for notification-catcher to fan out to Teams.
+    - target:
+        kind: Deployment
+        name: homerun2-omni-pitcher
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: homerun2-omni-pitcher
+        spec:
+          template:
+            spec:
+              containers:
+                - name: homerun2-omni-pitcher
+                  env:
+                    - name: ROUTES_CONFIG
+                      value: /etc/omni-pitcher/routes.yaml
+                  volumeMounts:
+                    - name: routes
+                      mountPath: /etc/omni-pitcher
+                      readOnly: true
+              volumes:
+                - name: routes
+                  configMap:
+                    name: homerun2-omni-pitcher-routes
+                    items:
+                      - key: routes.yaml
+                        path: routes.yaml

--- a/apps/homerun2/components/omni-pitcher/routes-configmap.yaml
+++ b/apps/homerun2/components/omni-pitcher/routes-configmap.yaml
@@ -1,0 +1,41 @@
+---
+# Routing config for omni-pitcher.
+#
+# Mounted into the omni-pitcher pod at /etc/omni-pitcher/routes.yaml via a
+# patch in release.yaml; the same patch sets ROUTES_CONFIG to that path so
+# the pitcher loads this at startup (see internal/routing/loader.go in
+# stuttgart-things/homerun2-omni-pitcher).
+#
+# Alertmanager and Grafana both POST to /pitch/grafana; both go to the
+# `alerts` stream so homerun2-notification-catcher (which consumes that
+# stream by default) can fan them out to Teams / generic webhooks based on
+# its own YAML config.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homerun2-omni-pitcher-routes
+  namespace: ${HOMERUN2_NAMESPACE:-homerun2}
+data:
+  routes.yaml: |
+    # Allowlist — every stream named in `routes:` or `default_stream`
+    # must appear here, else omni-pitcher fails startup.
+    streams:
+      - messages
+      - alerts
+      - github-events
+
+    # Catch-all stream when no rule matches.
+    default_stream: messages
+
+    # Ordered rules — first match wins.
+    routes:
+      # Alertmanager + Grafana webhooks → alerts stream for the
+      # notification-catcher pipeline.
+      - match:
+          endpoint: /pitch/grafana
+        stream: alerts
+
+      # GitHub webhook traffic stays on its dedicated stream.
+      - match:
+          endpoint: /pitch/github
+        stream: github-events

--- a/apps/homerun2/profiles/base/kustomization.yaml
+++ b/apps/homerun2/profiles/base/kustomization.yaml
@@ -5,4 +5,5 @@ components:
   - ../../components/redis-stack
   - ../../components/omni-pitcher
   - ../../components/core-catcher
+  - ../../components/notification-catcher
   - ../../components/scout

--- a/infra/kube-prometheus-stack/release.yaml
+++ b/infra/kube-prometheus-stack/release.yaml
@@ -86,10 +86,16 @@ spec:
                   storage: ${KPS_PROMETHEUS_STORAGE_SIZE:-10Gi}
 
     # ---- Alertmanager ----
-    # Routes warning|critical alerts to MS Teams via the in-cluster
-    # prometheus-msteams proxy (generic webhook_configs); the proxy
-    # formats the Adaptive Card. info-level alerts and the always-on
-    # Watchdog fall through to the null receiver and are dropped.
+    # Routes warning|critical alerts to MS Teams via the homerun2-notification-catcher
+    # pipeline:
+    #     AM ─▶ omni-pitcher /pitch/grafana ─▶ Redis stream "alerts"
+    #                                            └▶ notification-catcher ─▶ Teams
+    # The catcher does the Adaptive Card formatting (Go code, version-
+    # controlled) and applies its own filter (severity_min: warning) as a
+    # second-layer gate. info-level alerts and the always-on Watchdog still
+    # fall through to the null receiver and are dropped here.
+    # Replaces the previous prometheus-msteams proxy hop (kept deployed for
+    # now until the new path is verified; remove the proxy in a follow-up).
     alertmanager:
       enabled: true
       alertmanagerSpec:
@@ -118,11 +124,16 @@ spec:
           - name: 'null'
           - name: msteams
             webhook_configs:
-              # Delivered via the in-cluster prometheus-msteams proxy,
-              # which converts this to a Teams Adaptive Card. /alertmanager
-              # is the proxy connector name.
-              - url: http://prometheus-msteams.${KPS_NAMESPACE:-monitoring}.svc.cluster.local:2000/alertmanager
+              # Delivered to homerun2-omni-pitcher's /pitch/grafana endpoint
+              # (Alertmanager's webhook v4 payload is field-compatible with
+              # Grafana's). Bearer token matches the pitcher's AUTH_TOKEN.
+              # See: stuttgart-things/homerun2-notification-catcher/docs/alertmanager.md
+              - url: http://homerun2-omni-pitcher.${HOMERUN2_NAMESPACE:-homerun2}.svc.cluster.local/pitch/grafana
                 send_resolved: true
+                http_config:
+                  authorization:
+                    type: Bearer
+                    credentials: ${HOMERUN2_OMNI_PITCHER_AUTH_TOKEN:-changeme}
         inhibit_rules:
           - source_matchers: ['severity = "critical"']
             target_matchers: ['severity =~ "warning|info"']


### PR DESCRIPTION
## Summary

Replaces the `prometheus-msteams` proxy hop with the new **homerun2-notification-catcher** pipeline:

```
Alertmanager ─▶ omni-pitcher /pitch/grafana ─▶ Redis stream "alerts"
                                                     │
                                          notification-catcher
                                                     │
                                                ▶ MS Teams
```

Adaptive Card formatting and routing logic now live as version-controlled Go in [`stuttgart-things/homerun2-notification-catcher`](https://github.com/stuttgart-things/homerun2-notification-catcher) (Phase 1 — issues #5–#9, tags v1.0.0–v1.2.0).

## Changes

### New: `apps/homerun2/components/notification-catcher/`

OCIRepository + Flux Kustomization referencing `ghcr.io/.../homerun2-notification-catcher-kustomize`. Patches:

- container image tag (`HOMERUN2_NOTIFICATION_CATCHER_VERSION`, default `v1.2.0`)
- Redis Secret password (`HOMERUN2_REDIS_PASSWORD_B64`)
- env ConfigMap → point at `redis-stack.<ns>`
- output-secrets Secret → `TEAMS_WEBHOOK_URL` placeholder, substituted at apply time

No HTTPRoute — pure consumer.

### Updated: `apps/homerun2/components/omni-pitcher/`

- New `routes-configmap.yaml` — routes `/pitch/grafana` → `alerts` stream, keeps `github-events` on its dedicated stream.
- New patch in `release.yaml` mounting the ConfigMap at `/etc/omni-pitcher/` and setting `ROUTES_CONFIG=/etc/omni-pitcher/routes.yaml`.

### Updated: `apps/homerun2/profiles/base/kustomization.yaml`

Wires `notification-catcher` into the base profile alongside the other homerun2 components.

### Updated: `infra/kube-prometheus-stack/release.yaml`

Repoints the `msteams` receiver from `prometheus-msteams.<ns>:2000/alertmanager` to `homerun2-omni-pitcher.<ns>/pitch/grafana`. Bearer auth via `HOMERUN2_OMNI_PITCHER_AUTH_TOKEN`. AM severity routing (`warning|critical`) unchanged — the catcher's own `severity_min: warning` filter is the second-layer gate.

## Variables added

| Variable | Default | Description |
|---|---|---|
| `HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION` | `v1.2.0` | OCI kustomize artifact version |
| `HOMERUN2_NOTIFICATION_CATCHER_VERSION` | `v1.2.0` | Container image tag |
| `TEAMS_WEBHOOK_URL` | *(required)* | Power Automate webhook for the destination Teams channel — supply via `homerun2-flux-secrets` SOPS |

`HOMERUN2_REDIS_PASSWORD_B64` and `HOMERUN2_OMNI_PITCHER_AUTH_TOKEN` are already in use elsewhere.

## What still needs to happen on the cluster

1. **Add `TEAMS_WEBHOOK_URL` to `homerun2-flux-secrets`** (SOPS-encrypted). Without it the catcher fails startup — silent misconfig is deliberately rejected.
2. Reconcile.
3. Run the smoke procedure from [`homerun2-notification-catcher/docs/alertmanager.md`](https://github.com/stuttgart-things/homerun2-notification-catcher/blob/main/docs/alertmanager.md): POST a synthetic Alertmanager payload at omni-pitcher via `kubectl exec`, watch catcher logs, expect an Adaptive Card in the Teams channel.
4. Trip a real Prometheus alert to confirm end-to-end.

## Follow-up

`infra/prometheus-msteams/` (the proxy) is **still installed** so the previous path stays available during cutover. Remove it in a follow-up PR once the new path is verified.

## Verification

`kustomize build apps/homerun2/profiles/base` rendered cleanly — all notification-catcher resources present (OCIRepository, Kustomization, the four patches) plus the new `homerun2-omni-pitcher-routes` ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)