### PR TITLE
feat(backstage): enable OIDC (Zitadel) sign-in alongside GitHub

### DIFF
--- a/apps/backstage/pre-release.yaml
+++ b/apps/backstage/pre-release.yaml
@@ -124,3 +124,9 @@ spec:
           GITHUB_CLIENT_SECRET: ${BACKSTAGE_GITHUB_CLIENT_SECRET}
           BACKEND_SECRET: ${BACKSTAGE_BACKEND_SECRET}
           EXTERNAL_ACCESS_TOKEN: ${BACKSTAGE_EXTERNAL_ACCESS_TOKEN}
+          # ZITADEL OIDC client (see sthings-backstage#82 + zitadel-config TF module).
+          # Empty defaults so unset BACKSTAGE_ZITADEL_* doesn't break substitution
+          # in clusters that don't (yet) provision the secret.
+          ZITADEL_ISSUER: ${BACKSTAGE_ZITADEL_ISSUER:-}
+          ZITADEL_CLIENT_ID: ${BACKSTAGE_ZITADEL_CLIENT_ID:-}
+          ZITADEL_CLIENT_SECRET: ${BACKSTAGE_ZITADEL_CLIENT_SECRET:-}

--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -107,6 +107,30 @@ spec:
             secretKeyRef:
               name: backstage-secrets
               key: EXTERNAL_ACCESS_TOKEN
+        # ZITADEL / OIDC auth — Part 2 of the PR-preview auth spike
+        # (stuttgart-things/sthings-backstage#82). AUTH_OIDC_ENABLED gates
+        # both the backend module load and the SignInPage button; setting
+        # it to "true" surfaces the Zitadel sign-in option. The three
+        # secret-backed values come from the SOPS-encrypted
+        # backstage-secrets (BACKSTAGE_ZITADEL_*) provisioned by the
+        # zitadel-config Terraform module.
+        - name: AUTH_OIDC_ENABLED
+          value: "true"
+        - name: ZITADEL_ISSUER
+          valueFrom:
+            secretKeyRef:
+              name: backstage-secrets
+              key: ZITADEL_ISSUER
+        - name: ZITADEL_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: backstage-secrets
+              key: ZITADEL_CLIENT_ID
+        - name: ZITADEL_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: backstage-secrets
+              key: ZITADEL_CLIENT_SECRET
       extraAppConfig:
         - filename: app-config.extra.yaml
           configMapRef: backstage-app-config


### PR DESCRIPTION
## Summary
Completes Part 2 of stuttgart-things/sthings-backstage#82 by flipping \`AUTH_OIDC_ENABLED=true\` and wiring the three \`ZITADEL_*\` env vars into the production Backstage Deployment.

**Backstage code prerequisite** (already merged + released as v1.4.0): stuttgart-things/sthings-backstage#86 — adds the opt-in OIDC backend module + config-driven SignInPage. With \`AUTH_OIDC_ENABLED\` unset, that release behaves exactly like the previous one (verified after stuttgart-things/stuttgart-things#2220 + #2221).

This PR is the **opt-in flip**: turn on the OIDC backend module and surface the Zitadel button on the SignInPage.

## What's changed

### \`apps/backstage/pre-release.yaml\`
Adds 3 keys to the rendered \`backstage-secrets\` K8s Secret:
- \`ZITADEL_ISSUER\` ← \`\${BACKSTAGE_ZITADEL_ISSUER:-}\`
- \`ZITADEL_CLIENT_ID\` ← \`\${BACKSTAGE_ZITADEL_CLIENT_ID:-}\`
- \`ZITADEL_CLIENT_SECRET\` ← \`\${BACKSTAGE_ZITADEL_CLIENT_SECRET:-}\`

Empty defaults so substitution stays clean for clusters that don't (yet) provision these in SOPS.

### \`apps/backstage/release.yaml\`
Adds 4 env vars to the Backstage pod:
- \`AUTH_OIDC_ENABLED=\"true\"\` (literal — gates backend module + SignInPage button)
- \`ZITADEL_ISSUER\` / \`ZITADEL_CLIENT_ID\` / \`ZITADEL_CLIENT_SECRET\` (from \`backstage-secrets\` secretKeyRef)

## Non-breaking guarantees
- GitHub auth flow unchanged
- Empty-string defaults on \`BACKSTAGE_ZITADEL_*\` mean clusters without the SOPS keys still substitute cleanly. (Note: other clusters should leave \`AUTH_OIDC_ENABLED\` off until they actually provision the secret, otherwise OIDC discovery will fail at backend startup.)

## Test plan
- [ ] After merge + Flux reconcile on platform-sthings: Backstage pod restarts with the new env vars
- [ ] \`https://backstage.platform.sthings-vsphere.labul.sva.de\` still serves HTTP 200
- [ ] SignInPage now shows three buttons: Guest, GitHub, Zitadel
- [ ] Existing GitHub login still works (regression)
- [ ] Clicking Zitadel button → redirects to https://zitadel.homerun2-dev.../oauth/v2/authorize → back to Backstage with a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)