### PR TITLE
chore(notification-catcher): bump to v1.4.0 + DRY_RUN on first deploy

### DIFF
--- a/apps/homerun2/components/notification-catcher/README.md
+++ b/apps/homerun2/components/notification-catcher/README.md
@@ -26,8 +26,8 @@ OCIRepository + Flux Kustomization
 | Variable | Default | Description |
 |---|---|---|
 | `HOMERUN2_NAMESPACE` | `homerun2` | Target namespace |
-| `HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION` | `v1.2.0` | OCI kustomize artifact version |
-| `HOMERUN2_NOTIFICATION_CATCHER_VERSION` | `v1.2.0` | Container image tag |
+| `HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION` | `v1.4.0` | OCI kustomize artifact version |
+| `HOMERUN2_NOTIFICATION_CATCHER_VERSION` | `v1.4.0` | Container image tag |
 | `HOMERUN2_REDIS_PASSWORD_B64` | *(required)* | Base64-encoded Redis password |
 | `TEAMS_WEBHOOK_URL` | *(required)* | Power Automate webhook URL for the destination Teams channel |
 
@@ -39,6 +39,7 @@ OCIRepository + Flux Kustomization
 - Patches the Redis password Secret with the cluster's `HOMERUN2_REDIS_PASSWORD_B64`.
 - Patches the env ConfigMap to point at `redis-stack.<namespace>.svc.cluster.local:6379`.
 - Patches the output-secrets Secret with `TEAMS_WEBHOOK_URL`.
+- **Sets `DRY_RUN=true`** so the first reconciliation logs `dry-run: would send …` instead of posting to Teams. Remove this patch once routing is verified in `kubectl logs`.
 
 ## Routing config
 

--- a/apps/homerun2/components/notification-catcher/release.yaml
+++ b/apps/homerun2/components/notification-catcher/release.yaml
@@ -29,7 +29,29 @@ spec:
             spec:
               containers:
                 - name: homerun2-notification-catcher
-                  image: ghcr.io/stuttgart-things/homerun2-notification-catcher:${HOMERUN2_NOTIFICATION_CATCHER_VERSION:-v1.2.0}
+                  image: ghcr.io/stuttgart-things/homerun2-notification-catcher:${HOMERUN2_NOTIFICATION_CATCHER_VERSION:-v1.4.0}
+
+    # First-reconciliation guard: every dispatched alert is logged
+    # ("dry-run: would send …") instead of POSTing to Teams. Set DRY_RUN to
+    # any falsy value (or remove this patch) once routing is confirmed in
+    # `kubectl logs deploy/homerun2-notification-catcher`.
+    # Requires homerun2-notification-catcher v1.3.0 or later.
+    - target:
+        kind: Deployment
+        name: homerun2-notification-catcher
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: homerun2-notification-catcher
+        spec:
+          template:
+            spec:
+              containers:
+                - name: homerun2-notification-catcher
+                  env:
+                    - name: DRY_RUN
+                      value: "true"
 
     # Redis password — same SOPS-backed secret value the rest of homerun2 uses.
     - target:

--- a/apps/homerun2/components/notification-catcher/requirements.yaml
+++ b/apps/homerun2/components/notification-catcher/requirements.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/homerun2-notification-catcher-kustomize
   ref:
-    tag: ${HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION:-v1.2.0}
+    tag: ${HOMERUN2_NOTIFICATION_CATCHER_KUSTOMIZE_VERSION:-v1.4.0}


### PR DESCRIPTION
**Draft — please review.** Two coupled changes to land in the same reconciliation window. A follow-up PR removes the DRY_RUN patch once you've confirmed routing in `kubectl logs`.

## Changes

### 1. Version bump v1.2.0 → v1.4.0

- `release.yaml` — image tag default
- `requirements.yaml` — OCIRepository (kustomize base) tag default
- `README.md` — variable table

v1.3.0 added DRY_RUN. v1.4.0 is the current semantic-release tag (the merge of #16 in `homerun2-notification-catcher`).

### 2. DRY_RUN=true patch on the Deployment

A new patch in `release.yaml` injects `DRY_RUN=true` as an env var. The catcher still consumes the `alerts` stream and evaluates the YAML filters — matching outputs log `dry-run: would send  output=…  title=…  severity=…` instead of POSTing to Teams. Skipped outputs (filters didn't match) are reported the same way as in live mode.

## Operational recipe

1. Add `TEAMS_WEBHOOK_URL` to `homerun2-flux-secrets` (any placeholder string is fine — dry-run won't actually use it).
2. Merge this PR.
3. Reconcile.
4. Watch logs:

   ```bash
   kubectl logs -n homerun2 deploy/homerun2-notification-catcher -f | grep dry-run
   ```

   Expect lines per matching output. Trip a real Prometheus alert (or run the smoke procedure from `homerun2-notification-catcher/docs/alertmanager.md`) and confirm the right routing.
5. Once verified, open a follow-up PR removing the DRY_RUN patch — real notifications start flowing on next reconcile.
6. After verification, remove `infra/prometheus-msteams/` in a separate PR.

## Test plan

- [ ] `kustomize build apps/homerun2/profiles/base` renders cleanly with `DRY_RUN: "true"` and `image: …:v1.4.0`
- [ ] Reconcile in dry-run, confirm `dry-run: would send` lines in catcher logs for at least one synthetic alert
- [ ] Trip a real Prometheus alert, confirm logs name the expected output(s)
- [ ] Follow-up PR removes the DRY_RUN patch → real alerts flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)