### PR TITLE
docs(notification-catcher): rename homerun2-flux-secrets → homerun2-secrets

### DIFF
--- a/apps/homerun2/components/notification-catcher/README.md
+++ b/apps/homerun2/components/notification-catcher/README.md
@@ -31,7 +31,7 @@ OCIRepository + Flux Kustomization
 | `HOMERUN2_REDIS_PASSWORD_B64` | *(required)* | Base64-encoded Redis password |
 | `TEAMS_WEBHOOK_URL` | *(required)* | Power Automate webhook URL for the destination Teams channel |
 
-`TEAMS_WEBHOOK_URL` must be supplied via the parent stack's `substituteFrom: homerun2-flux-secrets`.
+`TEAMS_WEBHOOK_URL` must be supplied via the parent stack's `substituteFrom: homerun2-secrets`.
 
 ## Customizations
 
@@ -50,6 +50,6 @@ The catcher reads `/etc/notification-catcher/config.yaml` (a ConfigMap mounted b
 To wire in a new sink that needs a secret env var (PagerDuty, Slack, …):
 
 1. Extend the kustomize-base profile in `homerun2-notification-catcher/tests/kcl-deploy-profile.yaml` with the additional `outputSecrets` key and the YAML output stanza.
-2. Add the secret value to `homerun2-flux-secrets` (SOPS-encrypted) in the cluster repo.
+2. Add the secret value to `homerun2-secrets` (SOPS-encrypted) in the cluster repo.
 3. Add a patch here mapping the new key into the `<name>-secrets` Secret stringData (or extend the existing patch).
 4. Cut a new release of `homerun2-notification-catcher`; bump `HOMERUN2_NOTIFICATION_CATCHER_VERSION` here.

--- a/apps/homerun2/components/notification-catcher/release.yaml
+++ b/apps/homerun2/components/notification-catcher/release.yaml
@@ -84,7 +84,7 @@ spec:
     # Output secrets — webhook URLs for each Notifier the catcher dispatches
     # to. The KCL base emits placeholders; Flux substituteFrom on the
     # parent homerun2 stack rewrites ${TEAMS_WEBHOOK_URL} from the cluster's
-    # homerun2-flux-secrets Secret. If TEAMS_WEBHOOK_URL is not provided
+    # homerun2-secrets Secret. If TEAMS_WEBHOOK_URL is not provided
     # by substituteFrom, the catcher fails startup (silent misconfig is
     # the worst failure mode for a dispatch service).
     - target:


### PR DESCRIPTION
Matches the actual substitution Secret name on the cluster that consumes this component (\`platform-sthings\`, via \`clusters/labul/vsphere/platform-sthings/apps/homerun2-base-stack.yaml\` which ends \`substituteFrom: [Secret/homerun2-secrets]\`).

Doc-only — README prose and a comment on the output-secrets patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)