### PR TITLE
revert(backstage): disable OIDC env wiring — pairs with stuttgart-things image revert

### DIFF
--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -107,30 +107,6 @@ spec:
             secretKeyRef:
               name: backstage-secrets
               key: EXTERNAL_ACCESS_TOKEN
-        # ZITADEL / OIDC auth — Part 2 of the PR-preview auth spike
-        # (stuttgart-things/sthings-backstage#82). AUTH_OIDC_ENABLED gates
-        # both the backend module load and the SignInPage button; setting
-        # it to "true" surfaces the Zitadel sign-in option. The three
-        # secret-backed values come from the SOPS-encrypted
-        # backstage-secrets (BACKSTAGE_ZITADEL_*) provisioned by the
-        # zitadel-config Terraform module.
-        - name: AUTH_OIDC_ENABLED
-          value: "true"
-        - name: ZITADEL_ISSUER
-          valueFrom:
-            secretKeyRef:
-              name: backstage-secrets
-              key: ZITADEL_ISSUER
-        - name: ZITADEL_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name: backstage-secrets
-              key: ZITADEL_CLIENT_ID
-        - name: ZITADEL_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: backstage-secrets
-              key: ZITADEL_CLIENT_SECRET
       extraAppConfig:
         - filename: app-config.extra.yaml
           configMapRef: backstage-app-config


### PR DESCRIPTION
## Summary
Reverts #141 (the AUTH_OIDC_ENABLED + ZITADEL_* env vars added to the Backstage Deployment).

The Backstage v1.4.0 image is broken with a missing better-sqlite3 native binding for Node 24; we're rolling the image back to 07eedb69 in \`stuttgart-things\` (separate PR). The OIDC backend module + SignInPage button only exist in v1.4.0+, so the env vars are pointless against 07eedb69. Cleaning them up keeps the env in sync with the running image.

The \`BACKSTAGE_ZITADEL_*\` keys in \`pre-release.yaml\` and the backing SOPS values stay — harmless dead config, and ready to re-light when v1.4.0 is fixed and we re-bump.

## Test plan
- [ ] After merge + Flux reconcile, Backstage Deployment has no AUTH_OIDC_ENABLED / ZITADEL_* env vars
- [ ] Pod still healthy on 07eedb69, GitHub sign-in still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)