### PR TITLE
fix(notification-catcher): pin REDIS_STREAM=messages

### DIFF
--- a/apps/homerun2/components/notification-catcher/release.yaml
+++ b/apps/homerun2/components/notification-catcher/release.yaml
@@ -69,6 +69,14 @@ spec:
     # KCL default. (The kustomize base already defaults to redis-stack.<ns>
     # but we set it explicitly to mirror the core-catcher / omni-pitcher
     # components and to make the namespace override visible here.)
+    #
+    # REDIS_STREAM=messages: the omni-pitcher version currently deployed
+    # (v1.6.2) does not have the config-driven stream routing (added in
+    # v1.9.0+), so every /pitch/* webhook lands in the default stream
+    # `messages` regardless of the routes-configmap. Pinning catcher to
+    # `messages` keeps it picking up alerts until omni-pitcher is bumped.
+    # Once on v1.9.0+, drop this line (chart default is also `messages`
+    # as of homerun2-notification-catcher v2.0.2).
     - target:
         kind: ConfigMap
         name: homerun2-notification-catcher-env
@@ -80,6 +88,7 @@ spec:
         data:
           REDIS_ADDR: redis-stack.${HOMERUN2_NAMESPACE:-homerun2}.svc.cluster.local
           REDIS_PORT: "6379"
+          REDIS_STREAM: messages
 
     # Output secrets — webhook URLs for each Notifier the catcher dispatches
     # to. The KCL base emits placeholders; Flux substituteFrom on the


### PR DESCRIPTION
## Summary

Add a \`REDIS_STREAM: messages\` line to the env-CM patch on \`homerun2-notification-catcher\`.

## Why

The omni-pitcher version currently deployed in platform-sthings (v1.6.2) does not yet have the config-driven stream routing (that landed in v1.9.0+). So every \`/pitch/*\` webhook falls through to the default stream \`messages\`, ignoring the routes-configmap.yaml entries. Verified on cluster: a curl POST to \`/pitch/grafana\` lands in \`streamID=messages\`.

The notification-catcher was previously consuming \`alerts\` and never saw any messages. This patch pins it to \`messages\` so it actually receives alerts.

## Follow-up

Drop this line once omni-pitcher is bumped to v1.9.0+ (routing kicks in). The chart default (homerun2-notification-catcher v2.0.2+) is also \`messages\`, so removing the patch leaves the catcher correct.

## Test plan

- [ ] After merge + reconcile: \`kubectl exec\` (or \`kubectl describe deploy\`) shows \`REDIS_STREAM=messages\` in the catcher pod env.
- [ ] Pod log shows \`streams: ["messages"]\` at startup.
- [ ] \`curl -X POST /pitch/grafana ...\` lands a message that the catcher logs as \`dry-run: would send\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)