### PR TITLE
feat(notification-catcher): make DRY_RUN substitutable

### DIFF
--- a/apps/homerun2/components/notification-catcher/README.md
+++ b/apps/homerun2/components/notification-catcher/README.md
@@ -39,7 +39,7 @@ OCIRepository + Flux Kustomization
 - Patches the Redis password Secret with the cluster's `HOMERUN2_REDIS_PASSWORD_B64`.
 - Patches the env ConfigMap to point at `redis-stack.<namespace>.svc.cluster.local:6379`.
 - Patches the output-secrets Secret with `TEAMS_WEBHOOK_URL`.
-- **Sets `DRY_RUN=true`** so the first reconciliation logs `dry-run: would send …` instead of posting to Teams. Remove this patch once routing is verified in `kubectl logs`.
+- **Defaults `DRY_RUN=true`** so the first reconciliation logs `dry-run: would send …` instead of posting to Teams. Flip it from the consuming Kustomization once routing is verified in `kubectl logs` by setting `postBuild.substitute.HOMERUN2_NOTIFICATION_CATCHER_DRYRUN: "false"`.
 
 ## Routing config
 

--- a/apps/homerun2/components/notification-catcher/release.yaml
+++ b/apps/homerun2/components/notification-catcher/release.yaml
@@ -32,9 +32,11 @@ spec:
                   image: ghcr.io/stuttgart-things/homerun2-notification-catcher:${HOMERUN2_NOTIFICATION_CATCHER_VERSION:-v1.4.0}
 
     # First-reconciliation guard: every dispatched alert is logged
-    # ("dry-run: would send …") instead of POSTing to Teams. Set DRY_RUN to
-    # any falsy value (or remove this patch) once routing is confirmed in
-    # `kubectl logs deploy/homerun2-notification-catcher`.
+    # ("dry-run: would send …") instead of POSTing to Teams. Defaults to
+    # "true" so a fresh cluster never spams Teams; flip it from the
+    # consuming Kustomization once routing is confirmed in
+    # `kubectl logs deploy/homerun2-notification-catcher`:
+    #   postBuild.substitute.HOMERUN2_NOTIFICATION_CATCHER_DRYRUN: "false"
     # Requires homerun2-notification-catcher v1.3.0 or later.
     - target:
         kind: Deployment
@@ -51,7 +53,7 @@ spec:
                 - name: homerun2-notification-catcher
                   env:
                     - name: DRY_RUN
-                      value: "true"
+                      value: "${HOMERUN2_NOTIFICATION_CATCHER_DRYRUN:=true}"
 
     # Redis password — same SOPS-backed secret value the rest of homerun2 uses.
     - target:


### PR DESCRIPTION
## Summary
- Parameterise the `DRY_RUN` env-var patch on the notification-catcher Deployment via a new substitute var `HOMERUN2_NOTIFICATION_CATCHER_DRYRUN`.
- Default stays `"true"` so the first-reconciliation guard still protects clusters that haven't opted in.
- Cluster overlays can now toggle dry-run with one line in `postBuild.substitute` once routing has been verified in `kubectl logs deploy/homerun2-notification-catcher`.

## Test plan
- [ ] `flux build kustomization homerun2-base-stack --path ./apps/homerun2/profiles/base` (or equivalent local render) shows `DRY_RUN=true` when the substitute var is unset.
- [ ] Same render with `HOMERUN2_NOTIFICATION_CATCHER_DRYRUN=false` substituted shows `DRY_RUN=false`.
- [ ] After this merges and the consuming cluster overlay sets the var to `"false"`, the pod logs `"dry_run":false` at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)