### PR TITLE
feat(infra): external-secrets install + Vault cluster-store components

### DIFF
--- a/infra/external-secrets/README.md
+++ b/infra/external-secrets/README.md
@@ -1,0 +1,35 @@
+# external-secrets
+
+Two reusable Flux components for ESO on any cluster in this fleet:
+
+| Component | What it ships |
+|---|---|
+| `components/install/` | `Namespace` + `HelmRepository` + `HelmRelease` for the upstream `external-secrets/external-secrets` chart |
+| `components/cluster-store-vault/` | A Vault-backed `ClusterSecretStore` (Kubernetes auth, KV v2). Every field is parameterised via Flux substitution vars — point one or many `Kustomization`s at this component, each substituting a different `VAULT_CSS_NAME` / `VAULT_KV_PATH` / `VAULT_K8S_AUTH_MOUNT_PATH` to stand up multiple CSSes against different Vault mounts |
+
+Component layout matches `infra/cert-manager/components/install/` and is consumed the same way: a per-cluster Flux `Kustomization` (e.g. `clusters/labul/vsphere/platform-sthings/infra/external-secrets-install.yaml` in `stuttgart-things/stuttgart-things`) points at `./infra/external-secrets/components/<name>` and supplies `postBuild.substitute` overrides.
+
+## Prerequisites for `components/cluster-store-vault/`
+
+- ESO controller installed on the target cluster (`components/install/` above)
+- On Vault: KV mount + read policy created (`stuttgart-things/stuttgart-things: clusters/labul/vsphere/infra-sthings/vault-homerun2-secrets/`)
+- On Vault: Kubernetes auth backend + role bound to that policy (`stuttgart-things/stuttgart-things: clusters/labul/vsphere/<cluster>/vault-k8s-auth/`)
+- On target cluster: `vault-pki-ca` Secret in the `cert-manager` namespace holding the Vault server's CA (typical clusterbook output — present on both `homerun2-dev` and `platform-sthings`)
+
+## Substitution variables
+
+| Component | Var | Default | Notes |
+|---|---|---|---|
+| install | `EXTERNAL_SECRETS_NAMESPACE` | `external-secrets` | Namespace ESO runs in |
+| install | `EXTERNAL_SECRETS_VERSION` | `0.20.3` | Chart version |
+| install | `EXTERNAL_SECRETS_INSTALL_CRDS` | `true` | Chart's CRD install toggle |
+| cluster-store-vault | `VAULT_CSS_NAME` | `vault-homerun2-cd` | `metadata.name` of the rendered CSS |
+| cluster-store-vault | `VAULT_SERVER` | `https://vault.infra.sthings-vsphere.labul.sva.de` | Vault URL |
+| cluster-store-vault | `VAULT_KV_PATH` | `homerun2-cd` | KV v2 mount path |
+| cluster-store-vault | `VAULT_CA_SECRET_NAME` | `vault-pki-ca` | CA Secret name (in `cert-manager` ns) |
+| cluster-store-vault | `VAULT_CA_SECRET_NAMESPACE` | `cert-manager` | CA Secret namespace |
+| cluster-store-vault | `VAULT_CA_SECRET_KEY` | `ca.crt` | Key inside the CA Secret |
+| cluster-store-vault | `VAULT_K8S_AUTH_MOUNT_PATH` | `platform-sthings-eso` | Vault k8s auth mount path |
+| cluster-store-vault | `VAULT_K8S_AUTH_ROLE` | `eso` | Auth role name on Vault |
+| cluster-store-vault | `VAULT_K8S_AUTH_SA_NAME` | `eso` | SA name on the cluster |
+| cluster-store-vault | `VAULT_K8S_AUTH_SA_NAMESPACE` | `external-secrets` | SA namespace on the cluster |

--- a/infra/external-secrets/components/cluster-store-vault/cluster-secret-store.yaml
+++ b/infra/external-secrets/components/cluster-store-vault/cluster-secret-store.yaml
@@ -1,0 +1,32 @@
+---
+# Vault ClusterSecretStore — points ESO at a single Vault KV mount on
+# vault.infra.sthings-vsphere.labul.sva.de using Kubernetes auth. The
+# consumer (per-cluster Flux Kustomization) provides the variables; all
+# defaults match the homerun2-cd / platform-sthings shape so a no-vars
+# apply still produces a working resource.
+#
+# Pair with `clusters/<cluster>/vault-k8s-auth/` in
+# stuttgart-things/stuttgart-things — it provisions the matching Vault
+# auth role + on-cluster ServiceAccount that this CSS references.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: ${VAULT_CSS_NAME:-vault-homerun2-cd}
+spec:
+  provider:
+    vault:
+      server: ${VAULT_SERVER:-https://vault.infra.sthings-vsphere.labul.sva.de}
+      path: ${VAULT_KV_PATH:-homerun2-cd}
+      version: v2
+      caProvider:
+        type: Secret
+        name: ${VAULT_CA_SECRET_NAME:-vault-pki-ca}
+        namespace: ${VAULT_CA_SECRET_NAMESPACE:-cert-manager}
+        key: ${VAULT_CA_SECRET_KEY:-ca.crt}
+      auth:
+        kubernetes:
+          mountPath: ${VAULT_K8S_AUTH_MOUNT_PATH:-platform-sthings-eso}
+          role: ${VAULT_K8S_AUTH_ROLE:-eso}
+          serviceAccountRef:
+            name: ${VAULT_K8S_AUTH_SA_NAME:-eso}
+            namespace: ${VAULT_K8S_AUTH_SA_NAMESPACE:-external-secrets}

--- a/infra/external-secrets/components/cluster-store-vault/kustomization.yaml
+++ b/infra/external-secrets/components/cluster-store-vault/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - cluster-secret-store.yaml

--- a/infra/external-secrets/components/install/kustomization.yaml
+++ b/infra/external-secrets/components/install/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - requirements.yaml
+  - release.yaml

--- a/infra/external-secrets/components/install/release.yaml
+++ b/infra/external-secrets/components/install/release.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: ${EXTERNAL_SECRETS_NAMESPACE:-external-secrets}
+spec:
+  interval: 20m
+  chart:
+    spec:
+      chart: external-secrets
+      version: ${EXTERNAL_SECRETS_VERSION:-0.20.3}
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: ${EXTERNAL_SECRETS_NAMESPACE:-external-secrets}
+      interval: 12h
+  values:
+    installCRDs: ${EXTERNAL_SECRETS_INSTALL_CRDS:-true}

--- a/infra/external-secrets/components/install/requirements.yaml
+++ b/infra/external-secrets/components/install/requirements.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${EXTERNAL_SECRETS_NAMESPACE:-external-secrets}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: ${EXTERNAL_SECRETS_NAMESPACE:-external-secrets}
+spec:
+  interval: 24h
+  url: https://charts.external-secrets.io


### PR DESCRIPTION
## Summary
Step 4a prereq for Kargo (stuttgart-things/homerun2-omni-pitcher#116). Two reusable Flux components for ESO on any cluster in this fleet:

- `infra/external-secrets/components/install/` — `Namespace` + `HelmRepository` (charts.external-secrets.io) + `HelmRelease` (chart `external-secrets`, version pinned to `0.20.3`, CRDs enabled). Mirrors the `cert-manager/components/install/` shape.
- `infra/external-secrets/components/cluster-store-vault/` — a Vault-backed `ClusterSecretStore` (kubernetes auth, KV v2, caProvider). Every field — CSS name, KV path, k8s-auth mount path, SA reference — is parameterised via Flux substitution vars so the same template can stand up multiple CSSes against different Vault mounts.

Drives Step 4a (Kargo prereqs): ESO must run on `platform-sthings` so Kargo's project-scoped `ExternalSecret`s in `kargo-homerun2` can resolve git + GHCR PATs from `homerun2-cd/data/kargo`.

## Sibling draft PRs
- stuttgart-things/stuttgart-things#2231 — Vault TF (Vault auth role + on-cluster SA referenced by the CSS, plus `homerun2-cd` KV mount docs)
- stuttgart-things/stuttgart-things#2232 — per-cluster Flux Kustomizations consuming these components
- stuttgart-things/argocd#200 — Kargo chart whose `ExternalSecret`s reference the rendered CSS `vault-homerun2-cd`

Tracking issue: stuttgart-things/homerun2-omni-pitcher#116

## Test plan
- [ ] `kubectl kustomize infra/external-secrets/components/install` renders Namespace + HelmRepository + HelmRelease
- [ ] `kubectl kustomize infra/external-secrets/components/cluster-store-vault` renders a `ClusterSecretStore` with `${VAULT_*}` substitutions visible
- [ ] Once consumed via per-cluster Kustomization on `platform-sthings` (sibling PR), ESO pods reach `Running`
- [ ] Once consumed, `kubectl get clustersecretstore vault-homerun2-cd` reports `Ready: True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
