### PR TITLE
fix(homerun2/git-pitcher): delete stray bundle HTTPRoute

### DIFF
--- a/apps/homerun2/components/git-pitcher/release.yaml
+++ b/apps/homerun2/components/git-pitcher/release.yaml
@@ -25,6 +25,21 @@ spec:
         metadata:
           name: homerun2
         $patch: delete
+    # Remove the KCL-generated HTTPRoute. The bundle started shipping one
+    # with placeholder hostname (homerun2-git-pitcher.example.com) and parent
+    # homerun2-dev-gateway/default (preview-env default), which leaves a
+    # stray route on clusters that don't have that Gateway. Drop it here;
+    # if a real route is needed on a given cluster, add it as a sibling
+    # httproute.yaml the same way core-catcher does.
+    - target:
+        kind: HTTPRoute
+        name: homerun2-git-pitcher
+      patch: |
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: homerun2-git-pitcher
+        $patch: delete
     # Override the container image tag
     - target:
         kind: Deployment


### PR DESCRIPTION
## Summary
- Drops the stray `HTTPRoute/homerun2-git-pitcher` that the bundle has been shipping with KCL render-default placeholders since v0.9.x.
- Mirrors the pattern already used in `apps/homerun2/components/core-catcher/release.yaml`.

## Symptom (platform-sthings, post-v0.9.1 bump)

```
$ kubectl get httproute -n homerun2 homerun2-git-pitcher -o yaml
spec:
  hostnames:
    - homerun2-git-pitcher.example.com         # placeholder
  parentRefs:
    - name: homerun2-dev-gateway               # gateway doesn't exist here
      namespace: default
status: null                                   # no Gateway accepted it
```

The route was created on 2026-05-26 alongside the `homerun2-git-pitcher` Renovate bump to `v0.9.1` ([stuttgart-things/stuttgart-things#2044](https://github.com/stuttgart-things/stuttgart-things/pull/2044)). It doesn't break traffic today, but it's misleading state — and if `homerun2-dev-gateway` is ever created on the cluster later (the same name preview envs use), the stray would silently start trying to route.

## Why this matches an existing pattern

The KCL kustomize OCI for these services renders an HTTPRoute when the relevant flags are set; the Flux components here are split into:
- some that ship their own sibling `httproute.yaml` (e.g. core-catcher) — those *delete* the bundle's HTTPRoute in `release.yaml` and provide their own
- some that don't expose an HTTPRoute at all on this cluster — those should also delete the bundle's so it doesn't leak through

`git-pitcher` falls into the second bucket but was missing the delete patch. This PR adds it.

## Same root-cause class as
- `stuttgart-things/homerun2-core-catcher#68` (KCL render-default → bundle missing/extra manifests) — fixed earlier today, hardened `catcherMode` default to `"web"`.
- `stuttgart-things/stuttgart-things#2254` (bumped core-catcher kustomize OCI to v0.13.1).

## Test plan
- [ ] Flux reconciles: `flux reconcile kustomization homerun2-git-pitcher -n homerun2`
- [ ] `kubectl get httproute -n homerun2` no longer lists `homerun2-git-pitcher`
- [ ] `homerun2-git-pitcher` Pod + Service still present and healthy
- [ ] No regressions on other homerun2 services

🤖 Generated with [Claude Code](https://claude.com/claude-code)