### PR TITLE
fix(homerun2/git-pitcher): drop dead Namespace delete-patch from Flux release

### DIFF
--- a/apps/homerun2/components/git-pitcher/release.yaml
+++ b/apps/homerun2/components/git-pitcher/release.yaml
@@ -15,16 +15,6 @@ spec:
   wait: true
   targetNamespace: ${HOMERUN2_NAMESPACE:-homerun2}
   patches:
-    # Remove the KCL-generated Namespace (managed by the parent stack)
-    - target:
-        kind: Namespace
-        name: homerun2
-      patch: |
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: homerun2
-        $patch: delete
     # Remove the KCL-generated HTTPRoute. The bundle started shipping one
     # with placeholder hostname (homerun2-git-pitcher.example.com) and parent
     # homerun2-dev-gateway/default (preview-env default), which leaves a


### PR DESCRIPTION
## Summary

Removes the dead kustomize `$patch: delete` against `kind: Namespace, name: homerun2` from `apps/homerun2/components/git-pitcher/release.yaml`. This was the Flux counterpart of the same workaround already removed on the ArgoCD chart side in stuttgart-things/argocd#209.

The homerun2 service KCL profiles no longer emit a Namespace resource into their kustomize OCIs (stuttgart-things/homerun2-omni-pitcher#132 + all 8 service companions, merged). Once the next git-pitcher OCI is consumed here (via a `HOMERUN2_GIT_PITCHER_VERSION` bump), this patch's `target` won't match anything → Flux Kustomization goes ReconciliationFailed.

The `homerun2` namespace continues to be created by `apps/homerun2/components/redis-stack/requirements.yaml`.

## Rollout coupling

Must merge **before** `HOMERUN2_GIT_PITCHER_VERSION` is bumped to a release containing the namespace-removal KCL change (stuttgart-things/homerun2-git-pitcher#37).

## Test plan

- [ ] Flux CI passes (schema validation / kustomize build)
- [ ] After merge, verify `homerun2-git-pitcher` Flux Kustomization reconciles cleanly on platform-sthings once the next OCI version lands

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)