### PR TITLE
feat(apps/rancher): add Rancher app with HTTPRoute and private CA support

### DIFF
--- a/apps/rancher/README.md
+++ b/apps/rancher/README.md
@@ -69,7 +69,7 @@ spec:
   postBuild:
     substitute:
       RANCHER_NAMESPACE: cattle-system
-      RANCHER_VERSION: 2.11.2
+      RANCHER_VERSION: 2.14.2
       RANCHER_REPLICAS: "3"
       INGRESS_HOSTNAME: rancher
       INGRESS_DOMAIN: fluxdev-3.sthings-vsphere.example.com
@@ -89,7 +89,7 @@ Run `task get-variables` against this folder to list all `\${VAR:-default}` subs
 | Variable | Default | Purpose |
 |---|---|---|
 | `RANCHER_NAMESPACE` | `cattle-system` | Target namespace |
-| `RANCHER_VERSION` | `2.11.2` | Rancher chart version |
+| `RANCHER_VERSION` | `2.14.2` | Rancher chart version |
 | `RANCHER_REPLICAS` | `3` | Rancher replica count |
 | `STHINGS_CLUSTER_VERSION` | `0.3.20` | `sthings-cluster` helper chart version |
 | `INGRESS_HOSTNAME` | `rancher` | Hostname prefix |

--- a/apps/rancher/README.md
+++ b/apps/rancher/README.md
@@ -6,7 +6,11 @@ Deploys [Rancher](https://artifacthub.io/packages/helm/rancher-stable/rancher) v
 - TLS is terminated at the Gateway API `Gateway`; the chart runs with `ingress.enabled: false`
   and `tls: external`, and traffic is routed via a `HTTPRoute` (port `80`).
 - A private/internal CA is trusted via `privateCA: true` and the `tls-ca` secret
-  (`cacerts.pem`), supplied through the `${CA_BUNDLE}` substitution.
+  (`cacerts.pem`). That secret is distributed into the namespace by **trust-manager**
+  (see `infra/trust-manager`), so no CA material needs to be supplied to this app.
+
+> **Requires** `infra/trust-manager` with `secretTargets.enabled: true` and a Bundle
+> writing the `tls-ca` secret (`cacerts.pem`) into `${RANCHER_NAMESPACE}`.
 
 ## SECRET
 
@@ -21,10 +25,6 @@ metadata:
 type: Opaque
 stringData:
   BOOTSTRAP_PASSWORD: "ChangeMe123" #pragma: allowlist secret
-  CA_BUNDLE: |
-    -----BEGIN CERTIFICATE-----
-    ...your private CA bundle...
-    -----END CERTIFICATE-----
 EOF
 ```
 
@@ -98,4 +98,3 @@ Run `task get-variables` against this folder to list all `\${VAR:-default}` subs
 | `GATEWAY_NAME` | _(required)_ | Gateway API `Gateway` name |
 | `GATEWAY_NAMESPACE` | `default` | Gateway namespace |
 | `BOOTSTRAP_PASSWORD` | _(secret)_ | Initial admin bootstrap password |
-| `CA_BUNDLE` | _(secret)_ | Private CA bundle (`cacerts.pem`) |

--- a/apps/rancher/README.md
+++ b/apps/rancher/README.md
@@ -1,0 +1,101 @@
+# stuttgart-things/flux/rancher
+
+Deploys [Rancher](https://artifacthub.io/packages/helm/rancher-stable/rancher) via the
+`rancher-stable` Helm repo.
+
+- TLS is terminated at the Gateway API `Gateway`; the chart runs with `ingress.enabled: false`
+  and `tls: external`, and traffic is routed via a `HTTPRoute` (port `80`).
+- A private/internal CA is trusted via `privateCA: true` and the `tls-ca` secret
+  (`cacerts.pem`), supplied through the `${CA_BUNDLE}` substitution.
+
+## SECRET
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rancher
+  namespace: flux-system
+type: Opaque
+stringData:
+  BOOTSTRAP_PASSWORD: "ChangeMe123" #pragma: allowlist secret
+  CA_BUNDLE: |
+    -----BEGIN CERTIFICATE-----
+    ...your private CA bundle...
+    -----END CERTIFICATE-----
+EOF
+```
+
+## GIT-REPOSITORY MANIFEST
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: stuttgart-things-flux-rancher-dev
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  url: https://github.com/stuttgart-things/flux.git
+  ref:
+    branch: feature/add-rancher
+EOF
+```
+
+## KUSTOMIZATION EXAMPLE
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rancher
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: stuttgart-things-flux-rancher-dev
+  path: ./apps/rancher
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      RANCHER_NAMESPACE: cattle-system
+      RANCHER_VERSION: 2.11.2
+      RANCHER_REPLICAS: "3"
+      INGRESS_HOSTNAME: rancher
+      INGRESS_DOMAIN: fluxdev-3.sthings-vsphere.example.com
+      CLUSTER_ISSUER: cluster-issuer-approle
+      GATEWAY_NAME: cilium-gateway
+      GATEWAY_NAMESPACE: default
+    substituteFrom:
+      - kind: Secret
+        name: rancher
+EOF
+```
+
+## VARIABLES
+
+Run `task get-variables` against this folder to list all `\${VAR:-default}` substitutions.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RANCHER_NAMESPACE` | `cattle-system` | Target namespace |
+| `RANCHER_VERSION` | `2.11.2` | Rancher chart version |
+| `RANCHER_REPLICAS` | `3` | Rancher replica count |
+| `STHINGS_CLUSTER_VERSION` | `0.3.20` | `sthings-cluster` helper chart version |
+| `INGRESS_HOSTNAME` | `rancher` | Hostname prefix |
+| `INGRESS_DOMAIN` | _(required)_ | Base domain |
+| `CLUSTER_ISSUER` | _(required)_ | cert-manager `ClusterIssuer` for the gateway cert |
+| `GATEWAY_NAME` | _(required)_ | Gateway API `Gateway` name |
+| `GATEWAY_NAMESPACE` | `default` | Gateway namespace |
+| `BOOTSTRAP_PASSWORD` | _(secret)_ | Initial admin bootstrap password |
+| `CA_BUNDLE` | _(secret)_ | Private CA bundle (`cacerts.pem`) |

--- a/apps/rancher/httproute.yaml
+++ b/apps/rancher/httproute.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rancher-httproute
+  namespace: ${RANCHER_NAMESPACE:-cattle-system}
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: sthings-cluster
+      version: ${STHINGS_CLUSTER_VERSION:-0.3.20}
+      sourceRef:
+        kind: HelmRepository
+        name: stuttgart-things
+        namespace: ${RANCHER_NAMESPACE:-cattle-system}
+      interval: 12h
+  values:
+    customresources:
+      rancher-referencegrant:
+        apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: ReferenceGrant
+        metadata:
+          name: rancher-gateway-access
+          namespace: ${RANCHER_NAMESPACE:-cattle-system}
+          labels:
+            app.kubernetes.io/name: rancher
+            app.kubernetes.io/instance: rancher
+        spec:
+          from:
+            - group: gateway.networking.k8s.io
+              kind: Gateway
+              namespace: ${GATEWAY_NAMESPACE:-default}
+          to:
+            - group: ""
+              kind: Service
+      rancher-httproute:
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: HTTPRoute
+        metadata:
+          name: rancher
+          namespace: ${RANCHER_NAMESPACE:-cattle-system}
+          labels:
+            app.kubernetes.io/name: rancher
+            app.kubernetes.io/instance: rancher
+        spec:
+          hostnames:
+            - ${INGRESS_HOSTNAME:-rancher}.${INGRESS_DOMAIN}
+          parentRefs:
+            - name: ${GATEWAY_NAME}
+              namespace: ${GATEWAY_NAMESPACE:-default}
+          rules:
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /
+              backendRefs:
+                - name: rancher
+                  namespace: ${RANCHER_NAMESPACE:-cattle-system}
+                  port: 80

--- a/apps/rancher/httproute.yaml
+++ b/apps/rancher/httproute.yaml
@@ -55,6 +55,6 @@ spec:
                     type: PathPrefix
                     value: /
               backendRefs:
-                - name: rancher
+                - name: rancher-deployment
                   namespace: ${RANCHER_NAMESPACE:-cattle-system}
                   port: 80

--- a/apps/rancher/kustomization.yaml
+++ b/apps/rancher/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - pre-release.yaml
+  - httproute.yaml
+  - release.yaml

--- a/apps/rancher/pre-release.yaml
+++ b/apps/rancher/pre-release.yaml
@@ -31,9 +31,3 @@ spec:
             name: ${CLUSTER_ISSUER}
             kind: ClusterIssuer
           secretName: ${INGRESS_HOSTNAME:-rancher}.${INGRESS_DOMAIN}-tls
-    secrets:
-      rancher-cacerts:
-        name: tls-ca
-        dataType: stringData
-        secretKVs:
-          cacerts.pem: ${CA_BUNDLE}

--- a/apps/rancher/pre-release.yaml
+++ b/apps/rancher/pre-release.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rancher-certificate-configuration
+  namespace: ${RANCHER_NAMESPACE:-cattle-system}
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: sthings-cluster
+      version: ${STHINGS_CLUSTER_VERSION:-0.3.20}
+      sourceRef:
+        kind: HelmRepository
+        name: stuttgart-things
+        namespace: ${RANCHER_NAMESPACE:-cattle-system}
+      interval: 12h
+  values:
+    customresources:
+      rancher-ingress-certificate:
+        apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: rancher-ingress
+          namespace: ${RANCHER_NAMESPACE:-cattle-system}
+        spec:
+          commonName: ${INGRESS_HOSTNAME:-rancher}.${INGRESS_DOMAIN}
+          dnsNames:
+            - ${INGRESS_HOSTNAME:-rancher}.${INGRESS_DOMAIN}
+          issuerRef:
+            name: ${CLUSTER_ISSUER}
+            kind: ClusterIssuer
+          secretName: ${INGRESS_HOSTNAME:-rancher}.${INGRESS_DOMAIN}-tls
+    secrets:
+      rancher-cacerts:
+        name: tls-ca
+        dataType: stringData
+        secretKVs:
+          cacerts.pem: ${CA_BUNDLE}

--- a/apps/rancher/release.yaml
+++ b/apps/rancher/release.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: rancher
-      version: ${RANCHER_VERSION:-2.11.2}
+      version: ${RANCHER_VERSION:-2.14.2}
       sourceRef:
         kind: HelmRepository
         name: rancher-stable

--- a/apps/rancher/release.yaml
+++ b/apps/rancher/release.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rancher-deployment
+  namespace: ${RANCHER_NAMESPACE:-cattle-system}
+spec:
+  dependsOn:
+    - name: rancher-certificate-configuration
+      namespace: ${RANCHER_NAMESPACE:-cattle-system}
+  interval: 30m
+  chart:
+    spec:
+      chart: rancher
+      version: ${RANCHER_VERSION:-2.11.2}
+      sourceRef:
+        kind: HelmRepository
+        name: rancher-stable
+        namespace: ${RANCHER_NAMESPACE:-cattle-system}
+      interval: 12h
+  values:
+    hostname: ${INGRESS_HOSTNAME:-rancher}.${INGRESS_DOMAIN}
+    bootstrapPassword: ${BOOTSTRAP_PASSWORD}
+    replicas: ${RANCHER_REPLICAS:-3}
+    global:
+      cattle:
+        psp:
+          enabled: false
+    # TLS is terminated at the Gateway (HTTPRoute), so Rancher serves plain HTTP
+    ingress:
+      enabled: false
+    tls: external
+    # Trust a private/internal CA (cacerts.pem provided via the tls-ca secret)
+    privateCA: true

--- a/apps/rancher/requirements.yaml
+++ b/apps/rancher/requirements.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${RANCHER_NAMESPACE:-cattle-system}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: rancher-stable
+  namespace: ${RANCHER_NAMESPACE:-cattle-system}
+spec:
+  interval: 24h
+  url: https://releases.rancher.com/server-charts/stable
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: stuttgart-things
+  namespace: ${RANCHER_NAMESPACE:-cattle-system}
+spec:
+  type: oci
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things

--- a/infra/trust-manager/post-release.yaml
+++ b/infra/trust-manager/post-release.yaml
@@ -37,3 +37,24 @@ spec:
           target:
             configMap:
               key: ${TRUST_BUNDLE_TARGET_KEY:-trust-bundle.pem}
+      # Private-CA bundle written to a Secret for Rancher's privateCA (cacerts.pem).
+      # The synced Secret takes the Bundle's name, so it must match secretTargets.authorizedSecrets.
+      rancher-tls-ca:
+        apiVersion: trust.cert-manager.io/v1alpha1
+        kind: Bundle
+        metadata:
+          name: ${TRUST_BUNDLE_SECRET_NAME:-tls-ca}
+        spec:
+          sources:
+            - secret:
+                name: ${TRUST_BUNDLE_CA_SECRET:-cluster-ca-secret}
+                key: ${TRUST_BUNDLE_CA_KEY:-ca.crt}
+            - secret:
+                name: ${TRUST_BUNDLE_VAULT_CA_SECRET:-vault-pki-ca}
+                key: ${TRUST_BUNDLE_VAULT_CA_KEY:-ca.crt}
+          target:
+            secret:
+              key: ${TRUST_BUNDLE_SECRET_TARGET_KEY:-cacerts.pem}
+            namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: ${TRUST_BUNDLE_SECRET_NAMESPACE:-cattle-system}

--- a/infra/trust-manager/release.yaml
+++ b/infra/trust-manager/release.yaml
@@ -19,3 +19,8 @@ spec:
     app:
       trust:
         namespace: ${TRUST_MANAGER_TRUST_NAMESPACE:-cert-manager}
+    # Allow Bundles to write trust bundles into Secrets (e.g. rancher's privateCA tls-ca)
+    secretTargets:
+      enabled: true
+      authorizedSecrets:
+        - ${TRUST_BUNDLE_SECRET_NAME:-tls-ca}


### PR DESCRIPTION
## Summary
Adds a Flux Kustomize base at `apps/rancher` for deploying [Rancher](https://artifacthub.io/packages/helm/rancher-stable/rancher), and wires its private-CA trust through **trust-manager** (no hand-fed CA secret).

- **HTTP route instead of Ingress** — `ingress.enabled: false` + `tls: external`; TLS terminated at the Gateway API `Gateway`, traffic routed via `HTTPRoute` (→ `rancher-deployment` svc port 80) + a `ReferenceGrant`.
- **Private CA via trust-manager** — `privateCA: true` reads the `tls-ca` secret (`cacerts.pem`). That secret is produced by a trust-manager `Bundle` with a **Secret target**; `infra/trust-manager` now enables `secretTargets` (authorized for `tls-ca`). The app no longer needs a `CA_BUNDLE`.
- Default chart `2.14.2` (kubeVersion `< 1.36.0`) for current RKE2 (k8s 1.35); older 2.13.x caps at `< 1.35.0`.
- Upgraded apiVersions to `v2`/`v1`; everything parameterized with `${VAR:-default}`.

## Changes
**`apps/rancher/`** — `requirements.yaml`, `pre-release.yaml` (Certificate only), `httproute.yaml` (HTTPRoute + ReferenceGrant), `release.yaml`, `README.md`
**`infra/trust-manager/`** — `release.yaml` enables `secretTargets` (authorized: `tls-ca`); `post-release.yaml` adds a `tls-ca` Bundle writing `cacerts.pem` into the rancher namespace

## Test plan — validated on `platform-sthings` (labul/vsphere, k8s v1.35.1)
- [x] `kustomize build` passes for both `apps/rancher` and `infra/trust-manager`
- [x] Flux reconciles `apps/rancher` and `infra/trust-manager` from this branch
- [x] trust-manager runs with `--secret-targets-enabled=true`; `tls-ca` Bundle `Synced=True`
- [x] `tls-ca` secret (`cacerts.pem`) created in `cattle-system`, owned by `Bundle/tls-ca`
- [x] `HTTPRoute` `Accepted` + `ResolvedRefs` on the gateway
- [x] Rancher `2.14.2` healthy (`rancher-deployment`/`rancher-webhook` `1/1`)
- [x] `GET https://rancher.<domain>/` via gateway → **HTTP 200**

> Notes: cluster `vault-pki` issuer is currently failing for all certs (Vault `403`, also breaks `kargo-ingress`) — the gateway cert was validated with the healthy `cluster-ca` issuer. A transient quay.io `504` on the trust-pkg init image was worked around during the rollout (reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)