### PR TITLE
feat: add DD-WRT support to clusterbook and bump to v1.25.7

### DIFF
--- a/apps/clusterbook/README.md
+++ b/apps/clusterbook/README.md
@@ -33,9 +33,15 @@ spec:
       PDNS_ENABLED: "true"
       PDNS_URL: https://pdns.sthings-vsphere.labul.sva.de
       PDNS_ZONE: sthings.io
+      DDWRT_ENABLED: "true"
+      DDWRT_HOST: 192.168.1.1
+      DDWRT_USER: root
+      DDWRT_ZONE: sthings.lab
     substituteFrom:
       - kind: Secret
         name: clusterbook-pdns-vars
+      - kind: Secret
+        name: clusterbook-ddwrt-vars
 EOF
 ```
 
@@ -53,6 +59,11 @@ EOF
 | `PDNS_URL` | *(empty)* | PowerDNS API base URL |
 | `PDNS_ZONE` | *(empty)* | PowerDNS DNS zone |
 | `PDNS_TOKEN` | *(required if PDNS enabled)* | PowerDNS API key (via `substituteFrom` Secret) |
+| `DDWRT_ENABLED` | `false` | Enable DD-WRT integration |
+| `DDWRT_HOST` | *(empty)* | DD-WRT router host/IP |
+| `DDWRT_USER` | *(empty)* | DD-WRT login user |
+| `DDWRT_ZONE` | *(empty)* | DD-WRT DNS zone |
+| `DDWRT_PASSWORD` | *(required if DD-WRT enabled)* | DD-WRT login password (via `substituteFrom` Secret) |
 
 ## NetworkConfig CR
 

--- a/apps/clusterbook/README.md
+++ b/apps/clusterbook/README.md
@@ -25,7 +25,7 @@ spec:
   postBuild:
     substitute:
       CLUSTERBOOK_NAMESPACE: clusterbook
-      CLUSTERBOOK_VERSION: v1.11.0
+      CLUSTERBOOK_VERSION: v1.25.7
       CLUSTERBOOK_HOSTNAME: clusterbook
       GATEWAY_NAME: movie-scripts2-gateway
       GATEWAY_NAMESPACE: default
@@ -50,7 +50,7 @@ EOF
 | Variable | Default | Description |
 |---|---|---|
 | `CLUSTERBOOK_NAMESPACE` | `clusterbook` | Target namespace |
-| `CLUSTERBOOK_VERSION` | `v1.11.0` | Image + kustomize OCI tag |
+| `CLUSTERBOOK_VERSION` | `v1.25.7` | Image + kustomize OCI tag |
 | `CLUSTERBOOK_HOSTNAME` | `clusterbook` | HTTPRoute hostname prefix |
 | `GATEWAY_NAME` | *(required)* | Gateway API gateway name |
 | `GATEWAY_NAMESPACE` | `default` | Gateway namespace |

--- a/apps/clusterbook/ddwrt-secret.yaml
+++ b/apps/clusterbook/ddwrt-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clusterbook-ddwrt
+  namespace: ${CLUSTERBOOK_NAMESPACE:-clusterbook}
+type: Opaque
+stringData:
+  DDWRT_PASSWORD: ${DDWRT_PASSWORD}

--- a/apps/clusterbook/kustomization.yaml
+++ b/apps/clusterbook/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - release.yaml
   - httproute.yaml
   - pdns-secret.yaml
+  - ddwrt-secret.yaml

--- a/apps/clusterbook/release.yaml
+++ b/apps/clusterbook/release.yaml
@@ -29,7 +29,7 @@ spec:
             spec:
               containers:
                 - name: clusterbook
-                  image: ghcr.io/stuttgart-things/clusterbook:${CLUSTERBOOK_VERSION:-1.25.2}
+                  image: ghcr.io/stuttgart-things/clusterbook:${CLUSTERBOOK_VERSION:-v1.25.7}
     # Override PowerDNS + DD-WRT config in ConfigMap
     - target:
         kind: ConfigMap

--- a/apps/clusterbook/release.yaml
+++ b/apps/clusterbook/release.yaml
@@ -30,7 +30,7 @@ spec:
               containers:
                 - name: clusterbook
                   image: ghcr.io/stuttgart-things/clusterbook:${CLUSTERBOOK_VERSION:-1.25.2}
-    # Override PowerDNS config in ConfigMap
+    # Override PowerDNS + DD-WRT config in ConfigMap
     - target:
         kind: ConfigMap
         name: clusterbook-config
@@ -43,7 +43,11 @@ spec:
           PDNS_ENABLED: ${PDNS_ENABLED:-false}
           PDNS_URL: ${PDNS_URL:-}
           PDNS_ZONE: ${PDNS_ZONE:-}
-    # Add secretRef for PDNS token to Deployment
+          DDWRT_ENABLED: ${DDWRT_ENABLED:-false}
+          DDWRT_HOST: ${DDWRT_HOST:-}
+          DDWRT_USER: ${DDWRT_USER:-}
+          DDWRT_ZONE: ${DDWRT_ZONE:-}
+    # Add secretRefs for PDNS token + DD-WRT password to Deployment
     - target:
         kind: Deployment
         name: clusterbook
@@ -62,6 +66,8 @@ spec:
                         name: clusterbook-config
                     - secretRef:
                         name: clusterbook-pdns
+                    - secretRef:
+                        name: clusterbook-ddwrt
     # Remove the KCL-generated HTTPRoute (we provide our own via flux)
     - target:
         kind: HTTPRoute

--- a/apps/clusterbook/requirements.yaml
+++ b/apps/clusterbook/requirements.yaml
@@ -15,4 +15,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/clusterbook-kustomize
   ref:
-    tag: ${CLUSTERBOOK_VERSION:-1.25.2}
+    tag: ${CLUSTERBOOK_VERSION:-v1.25.7}


### PR DESCRIPTION
## What

Adds DD-WRT integration to the `apps/clusterbook` Flux app (mirroring the existing PowerDNS wiring) and bumps the app to the latest release `v1.25.7`.

## Changes

### DD-WRT support (mirrors PowerDNS)
- **New** `ddwrt-secret.yaml` — `clusterbook-ddwrt` Secret carrying `DDWRT_PASSWORD`.
- `kustomization.yaml` — adds `ddwrt-secret.yaml` to resources.
- `release.yaml` — ConfigMap patch now sets `DDWRT_ENABLED` / `DDWRT_HOST` / `DDWRT_USER` / `DDWRT_ZONE`; Deployment `envFrom` gains the `clusterbook-ddwrt` secretRef.

### Version bump
- `CLUSTERBOOK_VERSION` default `1.25.2` → `v1.25.7` (latest published release) in `release.yaml` and `requirements.yaml`.
- Adds the missing `v` prefix so the default matches the actual published OCI/image tags (only `v`-prefixed tags exist in GHCR — the old `1.25.2` default would not resolve).

### Docs
- README: documents the new `DDWRT_*` substitution variables + example values, and updates the version default/example to `v1.25.7`.

## Activating DD-WRT

Add to the consumer Kustomization's `postBuild.substitute` (keep the password in a `substituteFrom` Secret, out of git):

```yaml
DDWRT_ENABLED: "true"
DDWRT_HOST: 192.168.1.1
DDWRT_USER: root
DDWRT_ZONE: sthings.lab
# DDWRT_PASSWORD via substituteFrom Secret
```

## Notes
- The only genuinely new runtime pieces are the `clusterbook-ddwrt` Secret and its `secretRef`; everything else parallels the PowerDNS path.
- `pre-commit` is not installed in the build container, so YAML was validated with a parse check instead.

https://claude.ai/code/session_01AJ8fRn22QwjqMeWUUX4nok

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ8fRn22QwjqMeWUUX4nok)_