### PR TITLE
fix: stop autounseal from co-owning the vault namespace

### DIFF
--- a/apps/vault/autounseal/requirements.yaml
+++ b/apps/vault/autounseal/requirements.yaml
@@ -1,11 +1,9 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ${VAULT_NAMESPACE:-vault}
-  labels:
-    toolkit.fluxcd.io/tenant: sthings-team
----
+# NOTE: The vault Namespace is intentionally NOT declared here. It is owned by
+# the main vault Kustomization (apps/vault/requirements.yaml). Declaring it in
+# both bases makes two Flux Kustomizations fight over the namespace's ownership
+# labels, which churns the Cilium security identity of every pod in the
+# namespace and intermittently breaks pod networking (EPERM on connect).
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:


### PR DESCRIPTION
## Problem

`vault-ingress-tls` was failing to renew with a misleading error:

```
Vault failed to sign certificate: ... Post "http://vault-server.vault.svc.cluster.local:8200/v1/pki/sign/sthings-lab":
dial udp 10.43.0.10:53: connect: operation not permitted
```

The `operation not permitted` (EPERM) on a DNS `connect()` is not a normal DNS failure — it's Cilium denying the socket at the eBPF layer.

## Root cause

The `vault` Namespace was declared in **both** `apps/vault/requirements.yaml` and `apps/vault/autounseal/requirements.yaml`. Consumed as two separate Flux `Kustomization`s (`vault` and `vault-autounseal`), both apply the same Namespace object and overwrite each other's `kustomize.toolkit.fluxcd.io/{name,namespace}` ownership labels on every reconcile.

Cilium folds namespace labels into each pod's security identity, so this label flapping continuously churns the identity of every pod in the `vault` namespace and triggers identity garbage-collection while identities are still referenced. During those windows, socket-level service translation (kube-proxy replacement) fails closed and `connect()` returns EPERM — which surfaced as cert-manager being unable to reach DNS / vault-server and failing to renew the cert.

Confirmed in the live Cilium agent log: vault pods' identities flipped repeatedly, differing only by the namespace label `kustomize.toolkit.fluxcd.io/name = vault` vs `vault-autounseal`.

## Fix

A shared object like a Namespace must be owned by exactly one Kustomization. This removes the duplicate `Namespace` from the autounseal base; the `vault` namespace is now owned solely by the main `vault` Kustomization. autounseal depends on the vault release and deploys into the existing namespace, so the namespace always exists first.

https://claude.ai/code/session_019FCoGc41VrsZsVH4p3Mbs5

---
_Generated by [Claude Code](https://claude.ai/code/session_019FCoGc41VrsZsVH4p3Mbs5)_