### PR TITLE
feat: add pgvector Postgres (CNPG) for Backstage RAG-AI plugin

### DIFF
--- a/apps/backstage-rag-postgres/README.md
+++ b/apps/backstage-rag-postgres/README.md
@@ -1,0 +1,179 @@
+# backstage-rag-postgres
+
+A [CloudNativePG](https://cloudnative-pg.io) (CNPG) managed PostgreSQL with the
+[`pgvector`](https://github.com/pgvector/pgvector) extension, dedicated to the
+Backstage [Roadie RAG-AI plugin](https://github.com/RoadieHQ/rag-ai)
+(`@roadiehq/rag-ai`) for storing TechDocs/Catalog embeddings.
+
+This is a **second**, optional Postgres — it does **not** touch the Backstage
+core database (the embedded Bitnami Postgres in `apps/backstage`). Deploy it only
+in clusters that run the RAG plugin.
+
+## What Gets Deployed
+
+Into `${BACKSTAGE_NAMESPACE}` (default `portal`):
+
+1. **external-secret.yaml** — two `ExternalSecret`s (ESO → Vault):
+   - `rag-postgres-creds` (`kubernetes.io/basic-auth`) — owner `username`/`password`
+   - `rag-postgres-s3-creds` — MinIO `ACCESS_KEY_ID`/`SECRET_ACCESS_KEY` for backups
+2. **cluster.yaml** — the CNPG `Cluster` (`rag-postgres`): 1 instance, custom
+   pgvector image, `backstage_rag` DB owned by `rag`, `CREATE EXTENSION vector`,
+   5Gi storage, and WAL/base backups to MinIO via `barmanObjectStore`.
+3. **backup.yaml** — a Velero `Schedule` backing up the Kubernetes objects
+   (Cluster CR + the two ExternalSecrets, selected by label
+   `backup=backstage-rag-postgres`). Database *contents* are covered by CNPG's
+   own S3 backup; this covers the K8s *objects* for full DR.
+
+## Prerequisites
+
+- [`apps/cnpg-operator`](../cnpg-operator) reconciled (provides the CNPG CRDs)
+- [`infra/external-secrets`](../../infra/external-secrets) — ESO controller **and**
+  a Vault-backed `ClusterSecretStore` (default name `vault-cluster`)
+- A reachable MinIO and a pre-created backup bucket (see [Backups](#backups))
+- The pgvector operand image pushed to GHCR (see [Building the image](#building-the-pgvector-image))
+
+## Substitution Variables
+
+Run `task get-variables` in this folder for the full list. Key ones:
+
+| Var | Default | Notes |
+|---|---|---|
+| `BACKSTAGE_NAMESPACE` | `portal` | Namespace (same as Backstage) |
+| `STORAGE_CLASS` | `nfs4-csi` | PVC storage class |
+| `RAG_PG_IMAGE` | `ghcr.io/stuttgart-things/postgresql-pgvector` | pgvector operand image |
+| `RAG_PG_IMAGE_TAG` | `16` | Image tag (PG major) |
+| `RAG_PG_DATABASE` | `backstage_rag` | Bootstrap database |
+| `RAG_PG_OWNER` | `rag` | DB owner role |
+| `RAG_PG_STORAGE_SIZE` | `5Gi` | Volume size |
+| `RAG_ESO_STORE_NAME` | `vault-cluster` | `ClusterSecretStore` name |
+| `RAG_ESO_CREDS_PATH` | `kv/data/${BACKSTAGE_NAMESPACE}/rag-postgres` | Vault KV v2 path (owner creds) |
+| `RAG_ESO_S3_PATH` | `kv/data/${BACKSTAGE_NAMESPACE}/rag-postgres-s3` | Vault KV v2 path (S3 creds) |
+| `RAG_S3_BUCKET` | `backstage-rag-backups` | Backup bucket |
+| `RAG_S3_ENDPOINT` | `https://artifacts.${INGRESS_DOMAIN}` | MinIO S3 endpoint |
+| `RAG_BACKUP_RETENTION` | `7d` | CNPG backup retention |
+| `VELERO_NAMESPACE` | `velero` | Namespace for the `Schedule` |
+| `RAG_VELERO_CRON` | `0 1 * * *` | Velero schedule (daily 01:00) |
+| `RAG_VELERO_TTL` | `168h0m0s` | Velero retention (7 days) |
+
+## Required Vault Secrets
+
+Populate these KV v2 paths (defaults assume the `kv` mount; adjust to your
+`ClusterSecretStore` `path`):
+
+| Vault path | Keys |
+|---|---|
+| `kv/<ns>/rag-postgres` | `username`, `password` (the `rag` DB owner) |
+| `kv/<ns>/rag-postgres-s3` | `access_key`, `secret_key` (bucket-scoped MinIO user) |
+
+## Building the pgvector image
+
+CNPG's standard images don't bundle pgvector, so we ship a thin operand image
+(see [`image/Dockerfile`](image/Dockerfile)). Build & push manually (no CI yet):
+
+```bash
+docker buildx build \
+  --platform linux/amd64 \
+  -t ghcr.io/stuttgart-things/postgresql-pgvector:16 \
+  --push apps/backstage-rag-postgres/image
+```
+
+## Backups
+
+CNPG writes WAL + base backups to MinIO via `barmanObjectStore`. Pre-create the
+bucket and a bucket-scoped user (same approach as
+[`infra/velero/README.md`](../../infra/velero/README.md)):
+
+```bash
+mc mb myminio/backstage-rag-backups          # create the bucket
+# then create a user limited to that bucket and store its access/secret key in
+# Vault at kv/<ns>/rag-postgres-s3
+```
+
+## Enabling in a Cluster
+
+Per-cluster Flux `Kustomization`s live in `stuttgart-things/stuttgart-things`,
+not here. Add one referencing this path (confirm the `GitRepository` name):
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: backstage-rag-postgres
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: backstage
+    - name: cnpg-operator
+    - name: external-secrets
+  interval: 1h
+  retryInterval: 1m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: stuttgart-things # confirm the actual name in your cluster
+  path: ./apps/backstage-rag-postgres
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      BACKSTAGE_NAMESPACE: portal
+      STORAGE_CLASS: nfs4-csi
+      INGRESS_DOMAIN: automation.sthings-vsphere.labul.sva.de
+```
+
+## Connecting from the RAG plugin
+
+CNPG creates `-rw` (primary), `-ro` (replicas) and `-r` (any) services. Point
+the Roadie RAG plugin at the read-write service:
+
+```
+host:     rag-postgres-rw.${BACKSTAGE_NAMESPACE}.svc.cluster.local
+port:     5432
+database: backstage_rag
+user:     rag            # password from the rag-postgres-creds secret
+```
+
+## Verify
+
+```bash
+# Cluster healthy, primary elected
+kubectl -n portal get cluster rag-postgres
+kubectl -n portal get pods -l cnpg.io/cluster=rag-postgres
+
+# pgvector present
+kubectl -n portal exec -it rag-postgres-1 -- \
+  psql -U rag -d backstage_rag -c "\dx vector"
+
+# Services (expect rag-postgres-rw / -ro / -r)
+kubectl -n portal get svc | grep rag-postgres
+
+# vector smoke test
+kubectl -n portal run pgtest --rm -it --image=postgres:16 -- \
+  psql "postgresql://rag@rag-postgres-rw:5432/backstage_rag" \
+  -c "SELECT '[1,2,3]'::vector;"
+
+# backups
+kubectl -n portal get backup
+```
+
+## Restore
+
+CNPG restores into a **new** cluster from the Barman object store. Sketch:
+
+```yaml
+spec:
+  bootstrap:
+    recovery:
+      source: rag-postgres
+  externalClusters:
+    - name: rag-postgres
+      barmanObjectStore:
+        destinationPath: s3://backstage-rag-backups/
+        endpointURL: https://artifacts.<INGRESS_DOMAIN>
+        s3Credentials:
+          accessKeyId:    { name: rag-postgres-s3-creds, key: ACCESS_KEY_ID }
+          secretAccessKey: { name: rag-postgres-s3-creds, key: SECRET_ACCESS_KEY }
+```
+
+See the [CNPG recovery docs](https://cloudnative-pg.io/documentation/current/recovery/).

--- a/apps/backstage-rag-postgres/README.md
+++ b/apps/backstage-rag-postgres/README.md
@@ -77,6 +77,12 @@ docker buildx build \
   --push apps/backstage-rag-postgres/image
 ```
 
+The CNPG operand image is pulled by the kubelet (not Flux), so the GHCR package
+must be **public** — otherwise pods fail with `ErrImagePull`. New packages
+default to private; make it public once (Package settings → Change visibility),
+or add an `imagePullSecret` to the namespace and reference it via
+`spec.imagePullSecrets` in `cluster.yaml`.
+
 ## Backups
 
 CNPG writes WAL + base backups to MinIO via `barmanObjectStore`. Pre-create the

--- a/apps/backstage-rag-postgres/TESTING.md
+++ b/apps/backstage-rag-postgres/TESTING.md
@@ -1,0 +1,152 @@
+# Testing: backstage-rag-postgres + cnpg-operator
+
+A runbook for validating this app on a test cluster. Two paths: a no-cluster
+render check first, then a real Flux reconcile from this branch.
+
+> Branch under test: `feat/backstage-rag-pgvector` (PR
+> [#156](https://github.com/stuttgart-things/flux/pull/156)).
+
+## Key facts
+
+| Thing | Value |
+|---|---|
+| Operator | `apps/cnpg-operator` → ns `cnpg-system`, chart `cloudnative-pg` 0.28.2 |
+| DB app | `apps/backstage-rag-postgres` → ns `portal` (`BACKSTAGE_NAMESPACE`) |
+| Cluster CR | `rag-postgres`; services `rag-postgres-{rw,ro,r}` |
+| DB / owner | `backstage_rag` / `rag` |
+| Image (must exist) | `ghcr.io/stuttgart-things/postgresql-pgvector:16` |
+| ESO store | `vault-cluster` (`ClusterSecretStore`), KV v2 |
+| Vault paths | `kv/<ns>/rag-postgres` (`username`,`password`), `kv/<ns>/rag-postgres-s3` (`access_key`,`secret_key`) |
+| Backup bucket | `backstage-rag-backups` on MinIO |
+
+## tmux layout
+
+```bash
+tmux new -s rag
+# Ctrl-b "  → split; in the bottom pane run the watchers:
+watch -n5 'kubectl -n portal get cluster,pods,svc -l cnpg.io/cluster=rag-postgres 2>/dev/null; echo; flux get hr -n cnpg-system'
+# top pane = run the steps below
+```
+
+## Step 0 — no-cluster render check (fast, safe)
+
+```bash
+cd ~/projects/flux
+# raw kustomize (vars stay literal — just checks structure)
+kustomize build apps/cnpg-operator
+kustomize build apps/backstage-rag-postgres
+
+# render WITH substitution exactly like Flux will, then server-dry-run
+export BACKSTAGE_NAMESPACE=portal STORAGE_CLASS=nfs4-csi \
+       INGRESS_DOMAIN=automation.sthings-vsphere.labul.sva.de
+kustomize build apps/backstage-rag-postgres | envsubst | \
+  kubectl apply --dry-run=server -f -   # needs CNPG CRDs already on cluster
+```
+
+## Step 1 — prerequisites (one-time, env-specific)
+
+```bash
+# 1a. build + push the pgvector image (needs: docker login ghcr.io)
+docker buildx build --platform linux/amd64 \
+  -t ghcr.io/stuttgart-things/postgresql-pgvector:16 \
+  --push apps/backstage-rag-postgres/image
+
+# 1b. MinIO bucket (needs: mc alias 'myminio' configured)
+mc mb myminio/backstage-rag-backups
+
+# 1c. Vault secrets (needs: vault login) — adjust mount/path to your CSS
+vault kv put kv/portal/rag-postgres    username=rag password='<pw>'
+vault kv put kv/portal/rag-postgres-s3 access_key='<minio-key>' secret_key='<minio-secret>'
+```
+
+## Step 2 — point Flux at the branch & reconcile
+
+This repo is consumed by per-cluster Kustomizations, so the cleanest test is to
+temporarily point a `GitRepository` at this branch and apply two Flux
+`Kustomization`s to the **test** cluster (adjust the source name/URL if the
+cluster already has one).
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-rag-test
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://github.com/stuttgart-things/flux
+  ref:
+    branch: feat/backstage-rag-pgvector
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: { name: cnpg-operator, namespace: flux-system }
+spec:
+  interval: 5m
+  sourceRef: { kind: GitRepository, name: flux-rag-test }
+  path: ./apps/cnpg-operator
+  prune: true
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: { name: backstage-rag-postgres, namespace: flux-system }
+spec:
+  dependsOn:
+    - { name: cnpg-operator }
+  interval: 5m
+  sourceRef: { kind: GitRepository, name: flux-rag-test }
+  path: ./apps/backstage-rag-postgres
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      BACKSTAGE_NAMESPACE: portal
+      STORAGE_CLASS: nfs4-csi
+      INGRESS_DOMAIN: automation.sthings-vsphere.labul.sva.de
+EOF
+
+flux reconcile source git flux-rag-test
+flux get kustomizations
+```
+
+## Step 3 — verify
+
+```bash
+kubectl -n cnpg-system get pods                         # operator Running
+kubectl -n portal get cluster rag-postgres              # phase: Cluster in healthy state
+kubectl -n portal get pods -l cnpg.io/cluster=rag-postgres
+kubectl -n portal get externalsecret                    # both SecretSynced=True
+
+# pgvector present
+kubectl -n portal exec -it rag-postgres-1 -- \
+  psql -U rag -d backstage_rag -c "\dx vector"
+
+# vector smoke test
+kubectl -n portal run pgtest --rm -it --image=postgres:16 -- \
+  psql "postgresql://rag@rag-postgres-rw:5432/backstage_rag" -c "SELECT '[1,2,3]'::vector;"
+
+kubectl -n portal get svc | grep rag-postgres           # rw / ro / r
+```
+
+## Common failure points
+
+- **`ErrImagePull`** on `rag-postgres-1` → Step 1a not done, or image is private
+  (add an imagePullSecret).
+- **ExternalSecret `SecretSyncedError`** → wrong store name (`vault-cluster`?),
+  wrong KV path/mount, or Vault policy missing.
+  `kubectl -n portal describe externalsecret rag-postgres-creds`.
+- **Cluster stuck `Setting up primary`** → `kubectl -n portal logs rag-postgres-1`;
+  usually the owner secret keys aren't `username`/`password`.
+- **Backup errors** → bucket missing or wrong `INGRESS_DOMAIN`/endpoint:
+  `kubectl -n portal get cluster rag-postgres -o jsonpath='{.status.conditions}'`.
+
+## Teardown
+
+```bash
+kubectl -n flux-system delete kustomization backstage-rag-postgres cnpg-operator
+kubectl -n flux-system delete gitrepository flux-rag-test
+# CNPG Cluster + PVCs are pruned by Flux; double-check:
+kubectl -n portal get cluster,pvc -l cnpg.io/cluster=rag-postgres
+```

--- a/apps/backstage-rag-postgres/backup.yaml
+++ b/apps/backstage-rag-postgres/backup.yaml
@@ -1,0 +1,21 @@
+---
+# Velero Schedule for the RAG Postgres Kubernetes objects (Cluster CR, Secrets,
+# PVCs, ...). CNPG's barmanObjectStore (cluster.yaml) backs up the database
+# *contents* to MinIO; this backs up the K8s *objects* so a full restore is
+# possible. Selects only resources labelled backup=backstage-rag-postgres in
+# the Backstage namespace.
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: backstage-rag-postgres
+  namespace: ${VELERO_NAMESPACE:-velero}
+spec:
+  schedule: ${RAG_VELERO_CRON:-0 1 * * *}
+  template:
+    ttl: ${RAG_VELERO_TTL:-168h0m0s}
+    storageLocation: ${VELERO_BSL:-default}
+    includedNamespaces:
+      - ${BACKSTAGE_NAMESPACE:-portal}
+    labelSelector:
+      matchLabels:
+        backup: backstage-rag-postgres

--- a/apps/backstage-rag-postgres/cluster.yaml
+++ b/apps/backstage-rag-postgres/cluster.yaml
@@ -24,8 +24,11 @@ spec:
       # Secret (created by external-secret.yaml from Vault).
       secret:
         name: rag-postgres-creds
-      # Enable pgvector in the freshly bootstrapped database.
-      postInitSQL:
+      # Enable pgvector in the freshly bootstrapped *application* database.
+      # postInitApplicationSQL runs against the app DB (RAG_PG_DATABASE);
+      # postInitSQL would run against the `postgres` DB instead, leaving the
+      # extension absent from the database the RAG plugin actually connects to.
+      postInitApplicationSQL:
         - CREATE EXTENSION IF NOT EXISTS vector;
 
   storage:

--- a/apps/backstage-rag-postgres/cluster.yaml
+++ b/apps/backstage-rag-postgres/cluster.yaml
@@ -1,0 +1,61 @@
+---
+# CloudNativePG Cluster dedicated to the Backstage RAG-AI plugin. Single
+# instance (PoC — no HA), pgvector enabled, base/WAL backups to MinIO.
+# Requires apps/cnpg-operator and the rag-postgres-creds / rag-postgres-s3-creds
+# ExternalSecrets (external-secret.yaml) to exist first.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: rag-postgres
+  namespace: ${BACKSTAGE_NAMESPACE:-portal}
+  labels:
+    backup: backstage-rag-postgres
+spec:
+  instances: ${RAG_PG_INSTANCES:-1}
+  # Custom operand image: CNPG standard images don't bundle pgvector.
+  # Built from image/Dockerfile, pushed to ghcr.io/stuttgart-things.
+  imageName: ${RAG_PG_IMAGE:-ghcr.io/stuttgart-things/postgresql-pgvector}:${RAG_PG_IMAGE_TAG:-16}
+
+  bootstrap:
+    initdb:
+      database: ${RAG_PG_DATABASE:-backstage_rag}
+      owner: ${RAG_PG_OWNER:-rag}
+      # Owner username/password come from the rag-postgres-creds basic-auth
+      # Secret (created by external-secret.yaml from Vault).
+      secret:
+        name: rag-postgres-creds
+      # Enable pgvector in the freshly bootstrapped database.
+      postInitSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector;
+
+  storage:
+    size: ${RAG_PG_STORAGE_SIZE:-5Gi}
+    storageClass: ${STORAGE_CLASS:-nfs4-csi}
+
+  resources:
+    requests:
+      cpu: ${RAG_PG_CPU_REQUEST:-100m}
+      memory: ${RAG_PG_MEMORY_REQUEST:-256Mi}
+    limits:
+      cpu: ${RAG_PG_CPU_LIMIT:-1}
+      memory: ${RAG_PG_MEMORY_LIMIT:-1Gi}
+
+  # WAL + base backups straight to our MinIO via Barman Cloud. The Velero
+  # Schedule in backup.yaml covers the Kubernetes objects; this covers the
+  # database contents — together they give full DR.
+  backup:
+    retentionPolicy: ${RAG_BACKUP_RETENTION:-7d}
+    barmanObjectStore:
+      destinationPath: s3://${RAG_S3_BUCKET:-backstage-rag-backups}/
+      endpointURL: ${RAG_S3_ENDPOINT:-https://artifacts.${INGRESS_DOMAIN}}
+      s3Credentials:
+        accessKeyId:
+          name: rag-postgres-s3-creds
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: rag-postgres-s3-creds
+          key: SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip

--- a/apps/backstage-rag-postgres/external-secret.yaml
+++ b/apps/backstage-rag-postgres/external-secret.yaml
@@ -1,0 +1,73 @@
+---
+# Owner credentials for the RAG database. CNPG's bootstrap.initdb reads a
+# Secret of type kubernetes.io/basic-auth (keys: username, password) named in
+# cluster.yaml's bootstrap.initdb.secret. Pattern mirrors
+# infra/velero/components/external-secret/external-secret.yaml.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rag-postgres-creds
+  namespace: ${BACKSTAGE_NAMESPACE:-portal}
+  labels:
+    backup: backstage-rag-postgres
+spec:
+  refreshInterval: ${RAG_ESO_REFRESH_INTERVAL:-1h}
+  secretStoreRef:
+    name: ${RAG_ESO_STORE_NAME:-vault-cluster}
+    kind: ${RAG_ESO_STORE_KIND:-ClusterSecretStore}
+  target:
+    name: rag-postgres-creds
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          # CNPG only watches/decorates Secrets it manages unless told the
+          # owner secret belongs to the cluster; this label is informational.
+          cnpg.io/reload: "true"
+      data:
+        username: "{{ .username }}"
+        password: "{{ .password }}"
+  data:
+    - secretKey: username # pragma: allowlist secret
+      remoteRef:
+        key: ${RAG_ESO_CREDS_PATH:-kv/data/${BACKSTAGE_NAMESPACE}/rag-postgres}
+        property: ${RAG_ESO_CREDS_USERNAME_PROPERTY:-username}
+    - secretKey: password # pragma: allowlist secret
+      remoteRef:
+        key: ${RAG_ESO_CREDS_PATH:-kv/data/${BACKSTAGE_NAMESPACE}/rag-postgres}
+        property: ${RAG_ESO_CREDS_PASSWORD_PROPERTY:-password}
+---
+# MinIO/S3 credentials for CNPG's barmanObjectStore (WAL + base backups).
+# Reuses the same Vault-backed ClusterSecretStore as the owner creds; keys are
+# the bucket-scoped access/secret pair (see infra/velero/README.md for how to
+# provision a bucket-scoped MinIO user).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rag-postgres-s3-creds
+  namespace: ${BACKSTAGE_NAMESPACE:-portal}
+  labels:
+    backup: backstage-rag-postgres
+spec:
+  refreshInterval: ${RAG_ESO_REFRESH_INTERVAL:-1h}
+  secretStoreRef:
+    name: ${RAG_ESO_STORE_NAME:-vault-cluster}
+    kind: ${RAG_ESO_STORE_KIND:-ClusterSecretStore}
+  target:
+    name: rag-postgres-s3-creds
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        ACCESS_KEY_ID: "{{ .access_key }}"
+        SECRET_ACCESS_KEY: "{{ .secret_key }}"
+  data:
+    - secretKey: access_key # pragma: allowlist secret
+      remoteRef:
+        key: ${RAG_ESO_S3_PATH:-kv/data/${BACKSTAGE_NAMESPACE}/rag-postgres-s3}
+        property: ${RAG_ESO_S3_ACCESS_KEY_PROPERTY:-access_key}
+    - secretKey: secret_key # pragma: allowlist secret
+      remoteRef:
+        key: ${RAG_ESO_S3_PATH:-kv/data/${BACKSTAGE_NAMESPACE}/rag-postgres-s3}
+        property: ${RAG_ESO_S3_SECRET_KEY_PROPERTY:-secret_key}

--- a/apps/backstage-rag-postgres/image/Dockerfile
+++ b/apps/backstage-rag-postgres/image/Dockerfile
@@ -1,0 +1,37 @@
+# pgvector-enabled operand image for CloudNativePG.
+#
+# Why this exists: the CNPG community "standard" PostgreSQL images
+# (ghcr.io/cloudnative-pg/postgresql:*-standard-bookworm) bundle a useful set
+# of extensions but NOT pgvector. The Roadie @roadiehq/rag-ai plugin needs the
+# `vector` type/extension to store TechDocs/Catalog embeddings, so we extend the
+# standard image with the Debian pgvector package for PostgreSQL 16.
+#
+# Alternative (not used here): CNPG 1.27+ can mount extensions declaratively via
+# the official ghcr.io/cloudnative-pg/pgvector ImageVolume, but that needs the
+# Kubernetes ImageVolume feature gate enabled on the kubelet. Building a fat
+# operand image keeps this working on any cluster in the fleet.
+#
+# Build & push (manual — no CI wired yet):
+#   docker buildx build \
+#     --platform linux/amd64 \
+#     -t ghcr.io/stuttgart-things/postgresql-pgvector:16 \
+#     --push apps/backstage-rag-postgres/image
+#
+# Pin PG_MAJOR to match the base image's PostgreSQL major version.
+ARG PG_MAJOR=16
+FROM ghcr.io/cloudnative-pg/postgresql:${PG_MAJOR}-standard-bookworm
+
+ARG PG_MAJOR
+
+# CNPG runs as uid 26; switch to root only to install the package.
+USER root
+
+# DL3008: the pgvector package version tracks the base image's Debian release,
+# so pinning it here would break on every base-image bump — intentionally unpinned.
+# hadolint ignore=DL3008
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends "postgresql-${PG_MAJOR}-pgvector" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Drop back to the unprivileged postgres user CNPG expects.
+USER 26

--- a/apps/backstage-rag-postgres/kustomization.yaml
+++ b/apps/backstage-rag-postgres/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - cluster.yaml
+  - backup.yaml

--- a/apps/cnpg-operator/README.md
+++ b/apps/cnpg-operator/README.md
@@ -1,0 +1,62 @@
+# cnpg-operator
+
+Deploys the [CloudNativePG](https://cloudnative-pg.io) (CNPG) operator — a
+Kubernetes operator for managing PostgreSQL clusters declaratively.
+
+This is a **cluster-wide** install: a single operator in `cnpg-system` watches
+`Cluster` CRs in every namespace. It is a prerequisite for
+[`apps/backstage-rag-postgres`](../backstage-rag-postgres), which deploys a
+pgvector-enabled Postgres for the Backstage RAG-AI plugin.
+
+## What Gets Deployed
+
+1. **requirements.yaml** — `Namespace` (`cnpg-system` by default) and the
+   `cloudnative-pg` HelmRepository (`https://cloudnative-pg.github.io/charts`).
+2. **release.yaml** — the `cnpg-operator` HelmRelease (chart `cloudnative-pg`),
+   installing the operator and its CRDs (`Cluster`, `Backup`, `ScheduledBackup`,
+   `Pooler`, …) via `crds: CreateReplace`.
+
+## Substitution Variables
+
+| Var | Default | Notes |
+|---|---|---|
+| `CNPG_NAMESPACE` | `cnpg-system` | Namespace the operator runs in |
+| `CNPG_VERSION` | `0.28.2` | `cloudnative-pg` chart version |
+| `CNPG_CPU_REQUEST` | `100m` | Operator CPU request |
+| `CNPG_MEMORY_REQUEST` | `100Mi` | Operator memory request |
+| `CNPG_MEMORY_LIMIT` | `200Mi` | Operator memory limit |
+
+Run `task get-variables` in this folder to (re)generate the list.
+
+## Enabling in a Cluster
+
+Per-cluster Flux `Kustomization`s live in `stuttgart-things/stuttgart-things`,
+not in this repo. Point one at this path (confirm the `GitRepository` name your
+cluster uses):
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: stuttgart-things # confirm the actual name in your cluster
+  path: ./apps/cnpg-operator
+  prune: true
+  wait: true
+```
+
+## Verify
+
+```bash
+kubectl -n cnpg-system get pods           # cnpg-controller-manager Running
+flux get hr -n cnpg-system                # cnpg-operator Ready
+kubectl get crd | grep cnpg.io            # clusters.postgresql.cnpg.io, ...
+```

--- a/apps/cnpg-operator/kustomization.yaml
+++ b/apps/cnpg-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml

--- a/apps/cnpg-operator/release.yaml
+++ b/apps/cnpg-operator/release.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cnpg-operator
+  namespace: ${CNPG_NAMESPACE:-cnpg-system}
+spec:
+  interval: 30m
+  timeout: 10m
+  chart:
+    spec:
+      chart: cloudnative-pg
+      version: ${CNPG_VERSION:-0.28.2}
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: ${CNPG_NAMESPACE:-cnpg-system}
+      interval: 12h
+  install:
+    # The chart ships the CloudNativePG CRDs (Cluster, Backup, Scheduled-
+    # Backup, Pooler, ...). crds: CreateReplace lets Flux install/upgrade
+    # them with the release so apps/backstage-rag-postgres can apply a
+    # Cluster CR once this operator reconciles.
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    # Cluster-wide install: the operator watches Clusters in every
+    # namespace (default chart behaviour), so a single instance serves
+    # the RAG database in the Backstage namespace and any future tenants.
+    resources:
+      requests:
+        cpu: ${CNPG_CPU_REQUEST:-100m}
+        memory: ${CNPG_MEMORY_REQUEST:-100Mi}
+      limits:
+        memory: ${CNPG_MEMORY_LIMIT:-200Mi}

--- a/apps/cnpg-operator/requirements.yaml
+++ b/apps/cnpg-operator/requirements.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CNPG_NAMESPACE:-cnpg-system}
+  labels:
+    toolkit.fluxcd.io/tenant: sthings-team
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+  namespace: ${CNPG_NAMESPACE:-cnpg-system}
+spec:
+  interval: 24h
+  url: https://cloudnative-pg.github.io/charts

--- a/docs/apps/backstage-rag-postgres.md
+++ b/docs/apps/backstage-rag-postgres.md
@@ -1,0 +1,53 @@
+# Backstage RAG Postgres
+
+A [CloudNativePG](https://cloudnative-pg.io)-managed PostgreSQL with the
+[`pgvector`](https://github.com/pgvector/pgvector) extension, dedicated to the
+Backstage [Roadie RAG-AI plugin](https://github.com/RoadieHQ/rag-ai) for storing
+TechDocs/Catalog embeddings. Optional, second database — separate from the
+Backstage core DB.
+
+## Prerequisites
+
+- [CNPG Operator](cnpg-operator.md) reconciled
+- External Secrets controller + a Vault `ClusterSecretStore` (`vault-cluster`)
+- A pgvector operand image pushed to `ghcr.io/stuttgart-things/postgresql-pgvector`
+- A MinIO backup bucket (`backstage-rag-backups`) and bucket-scoped user
+
+## Deploy
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: backstage-rag-postgres
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: backstage
+    - name: cnpg-operator
+    - name: external-secrets
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: stuttgart-things # confirm the name in your cluster
+  path: ./apps/backstage-rag-postgres
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      BACKSTAGE_NAMESPACE: portal
+      STORAGE_CLASS: nfs4-csi
+      INGRESS_DOMAIN: automation.sthings-vsphere.labul.sva.de
+```
+
+## Connection
+
+```
+host: rag-postgres-rw.<BACKSTAGE_NAMESPACE>.svc.cluster.local
+db:   backstage_rag
+user: rag
+```
+
+See [`apps/backstage-rag-postgres/README.md`](https://github.com/stuttgart-things/flux/tree/main/apps/backstage-rag-postgres)
+for required Vault paths, image build, backups, verification and restore.

--- a/docs/apps/cnpg-operator.md
+++ b/docs/apps/cnpg-operator.md
@@ -1,0 +1,36 @@
+# CNPG Operator
+
+The [CloudNativePG](https://cloudnative-pg.io) operator for managing PostgreSQL
+clusters declaratively. Cluster-wide install in `cnpg-system`; a prerequisite
+for [Backstage RAG Postgres](backstage-rag-postgres.md).
+
+## Deploy
+
+Point a Flux `Kustomization` at `./apps/cnpg-operator`:
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnpg-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: GitRepository
+    name: stuttgart-things # confirm the name in your cluster
+  path: ./apps/cnpg-operator
+  prune: true
+  wait: true
+```
+
+## Substitution Variables
+
+| Var | Default |
+|---|---|
+| `CNPG_NAMESPACE` | `cnpg-system` |
+| `CNPG_VERSION` | `0.28.2` |
+
+See [`apps/cnpg-operator/README.md`](https://github.com/stuttgart-things/flux/tree/main/apps/cnpg-operator)
+for the full reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,9 @@ nav:
   - Apps:
       - Overview: apps/index.md
       - Argo CD: apps/argo-cd.md
+      - Backstage RAG Postgres: apps/backstage-rag-postgres.md
       - Claim Machinery API: apps/claim-machinery-api.md
+      - CNPG Operator: apps/cnpg-operator.md
       - Clusterbook: apps/clusterbook.md
       - Flux Web: apps/flux-web.md
       - Headlamp: apps/headlamp.md


### PR DESCRIPTION
## What

Adds a **CloudNativePG (CNPG)**-managed PostgreSQL with the **pgvector** extension, dedicated to the Backstage [Roadie RAG-AI plugin](https://github.com/RoadieHQ/rag-ai) (`@roadiehq/rag-ai`) for storing TechDocs/Catalog embeddings. This is a **second, optional** database — it does not touch the Backstage core Postgres.

## Deliverables

### `apps/cnpg-operator/` — cluster-wide CNPG operator
- `requirements.yaml` (ns `cnpg-system` + HTTPS HelmRepository), `release.yaml` (chart `cloudnative-pg` `0.28.2`, CRDs via `crds: CreateReplace`), `kustomization.yaml`, `README.md`

### `apps/backstage-rag-postgres/` — the RAG database
- `image/Dockerfile` — extends `ghcr.io/cloudnative-pg/postgresql:16-standard-bookworm` with `postgresql-16-pgvector` (CNPG standard images don't bundle pgvector); push target `ghcr.io/stuttgart-things/postgresql-pgvector:16`
- `cluster.yaml` — CNPG `Cluster rag-postgres`: 1 instance (PoC), `backstage_rag` DB owned by `rag`, `postInitSQL: CREATE EXTENSION vector`, 5Gi storage, modest resources, WAL/base backups to MinIO via `barmanObjectStore`
- `external-secret.yaml` — two ESO `ExternalSecret`s (owner basic-auth creds + S3 creds) against the `vault-cluster` ClusterSecretStore, KV v2 paths
- `backup.yaml` — Velero `Schedule` (daily, 7-day TTL) for the Kubernetes objects
- `README.md` — consumer Flux `Kustomization` snippet, Vault paths, image build, bucket pre-creation, verify (`\dx vector`), restore

### Docs
- `docs/apps/{cnpg-operator,backstage-rag-postgres}.md` + `mkdocs.yml` nav entries

## Patterns reused
- Flat `requirements`/`release` layout like `apps/backstage`
- ESO `ExternalSecret` shape from `infra/velero` (`vault-cluster`, `kv/data/...`)
- HTTPS `HelmRepository` like `infra/cert-manager`
- Everything parameterised via `postBuild.substitute`

## Notes / deviations from the original spec
- **No `clusters/` dir** in this (library) repo — cluster-side Flux wiring is documented as a consumer snippet in the READMEs (like `infra/external-secrets`), not committed here.
- **No `s3-flux-secrets` secret / MinIO bucket Job exist** — followed velero's actual ESO pattern and documented bucket creation (`mc mb`) instead.
- pgvector image **build/push is manual** (no CI wired) — documented in the Dockerfile + README.

## Before enabling on a cluster
Confirm the cluster's `GitRepository` source name and `ClusterSecretStore` name (left as substitutable defaults), and populate the Vault paths.

## Validation
- `kustomize build` clean on both folders (valid YAML)
- `pre-commit run` passes (whitespace, hadolint, detect-secrets)

## Out of scope (per spec)
Backstage core DB migration; HA replicas; Roadie plugin install/config; Prometheus rules; CI to build/push the pgvector image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)