### PR TITLE
feat: add argocd-platform bundle (argo-cd + clusterbook-operator + config)

### DIFF
--- a/cicd/argocd-platform/README.md
+++ b/cicd/argocd-platform/README.md
@@ -1,0 +1,100 @@
+# argocd-platform
+
+A **bundle** that stands up the full Argo CD platform from a single Flux
+`Kustomization`. Instead of the consumer wiring up Argo CD, the
+clusterbook-operator, and the Argo CD config as three separate Kustomizations,
+they point one Kustomization at `./cicd/argocd-platform` and get all three —
+correctly ordered.
+
+## What it deploys
+
+```
+argocd-platform-argo-cd            # ./cicd/argo-cd            (HelmRelease — Argo CD itself)
+  ├─ argocd-platform-clusterbook-operator   # ./apps/clusterbook-operator   (dependsOn argo-cd)
+  └─ argocd-platform-argocd-config          # ./cicd/argocd-platform/config (dependsOn argo-cd)
+```
+
+The bundle's `kustomization.yaml` does not list raw manifests — it lists three
+Flux `Kustomization` CRs (`ks-*.yaml`). When the consumer's Kustomization builds
+the bundle, Flux substitutes `${VAR:-default}` into those child CRs, so each one
+ends up with concrete `postBuild.substitute` values. `dependsOn` guarantees
+Argo CD is healthy before the operator or any Argo CD CR (AppProject /
+ApplicationSet) is applied — avoiding CRD races.
+
+## The label chain
+
+```
+argo-cd up
+  └─> clusterbook-operator   reconciles ClusterbookCluster CRs →
+                             registers each cluster as an Argo CD cluster-secret + stamps labels
+        └─> appset-cluster-projects  (cluster generator) → one AppProject per cluster
+        └─> platform AppSets         (from argocd-catalog) → select on those labels → deploy
+```
+
+## What is / isn't in the bundle
+
+| In the bundle (fleet-generic, reusable) | Stays per-cluster (consumer repo) |
+|---|---|
+| `cicd/argo-cd` (Argo CD install) | `ClusterbookCluster` CRs (`clusterbook-cluster-<name>.yaml`) |
+| `apps/clusterbook-operator` | Which platforms to enable (`*-platform-appsets.yaml` → `argocd-catalog`) |
+| `config/appset-cluster-projects.yaml` (AppProject per cluster) | Label gates on the ClusterbookCluster CR (`network-platform/*`, …) |
+| `config/proj-cicd.yaml` (cicd AppProject) | |
+
+Platform selection is label-driven on the `ClusterbookCluster` CR, so the bundle
+stays generic and each fleet opts into platforms without forking it.
+
+## Consumer usage
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: argocd-platform
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: apps-upstream          # url: https://github.com/stuttgart-things/flux.git
+  path: ./cicd/argocd-platform
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      FLUX_SOURCE: apps-upstream
+      ARGO_CD_VERSION: "9.4.15"
+      ARGO_CD_NAMESPACE: argocd
+      INGRESS_DOMAIN: platform.sthings-vsphere.labul.sva.de
+      CLUSTERBOOK_OPERATOR_VERSION: v0.19.0
+      # …override any ${VAR} from `task get-variables`
+    substituteFrom:
+      - kind: Secret
+        name: argocd-secrets
+```
+
+> The `${ARGO_CD_*}` substitutions feed `cicd/argo-cd`, which also reads the
+> `argocd-secrets` Secret via `substituteFrom`. That Secret must exist in
+> `flux-system` on the target cluster.
+
+## Variables
+
+```bash
+task get-variables   # extract every ${VAR:-default} in this folder
+```
+
+| Variable | Default | Used by |
+|---|---|---|
+| `BUNDLE_NAME` | `argocd-platform` | child Kustomization names + `dependsOn` refs |
+| `FLUX_SOURCE` | `apps-upstream` | `sourceRef.name` of every child Kustomization |
+| `ARGO_CD_VERSION` | `9.4.15` | argo-cd |
+| `ARGO_CD_NAMESPACE` | `argocd` | argo-cd, health check |
+| `CLUSTERBOOK_OPERATOR_VERSION` | `v0.19.0` | clusterbook-operator |
+| `CLUSTERBOOK_OPERATOR_NAMESPACE` | `clusterbook-system` | clusterbook-operator |
+
+(plus the Argo CD ingress / issuer / AVP vars passed through to `cicd/argo-cd` —
+see `ks-argo-cd.yaml`.)
+
+> Run multiple isolated bundles on one cluster by setting a distinct
+> `BUNDLE_NAME` per consumer Kustomization.

--- a/cicd/argocd-platform/config/appset-cluster-projects.yaml
+++ b/cicd/argocd-platform/config/appset-cluster-projects.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-projects
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            auto-project: "true"
+  template:
+    metadata:
+      name: 'proj-{{ .name }}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/stuttgart-things/argocd.git
+        targetRevision: main
+        path: config/cluster-project/chart
+        helm:
+          releaseName: 'proj-{{ .name }}'
+          valuesObject:
+            cluster:
+              name: '{{ .name }}'
+              server: '{{ .server }}'
+            allowAll: '{{ index .metadata.labels "allow-all" | default "false" }}'
+            tier: '{{ index .metadata.labels "tier" | default "" }}'
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: argocd
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true

--- a/cicd/argocd-platform/config/kustomization.yaml
+++ b/cicd/argocd-platform/config/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# Reusable, fleet-generic Argo CD configuration applied into the argocd
+# namespace. Per-cluster data (ClusterbookCluster CRs) and the choice of which
+# platform AppSets to enable stay in the consumer/cluster repo — they differ per
+# fleet and are selected via labels on the ClusterbookCluster CR.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - appset-cluster-projects.yaml
+  - proj-cicd.yaml

--- a/cicd/argocd-platform/config/proj-cicd.yaml
+++ b/cicd/argocd-platform/config/proj-cicd.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: cicd-mgmt-1
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  description: Apps deployed to the cicd-mgmt-1 kind cluster
+
+  sourceRepos:
+    - 'https://github.com/stuttgart-things/*'
+    - 'oci://ghcr.io/stuttgart-things/*'
+    - 'https://github.com/stefanprodan/podinfo'
+
+  destinations:
+    - name: cicd-mgmt-1
+      namespace: '*'
+    - name: in-cluster
+      namespace: '*'
+
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+
+  orphanedResources:
+    warn: true

--- a/cicd/argocd-platform/ks-argo-cd.yaml
+++ b/cicd/argocd-platform/ks-argo-cd.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ${BUNDLE_NAME:-argocd-platform}-argo-cd
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: cicd
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: ${FLUX_SOURCE:-apps-upstream}
+  path: ./cicd/argo-cd
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      ARGO_CD_VERSION: ${ARGO_CD_VERSION:-9.4.15}
+      ARGO_CD_NAMESPACE: ${ARGO_CD_NAMESPACE:-argocd}
+      ARGO_CD_INGRESS_ENABLED: ${ARGO_CD_INGRESS_ENABLED:-false}
+      INGRESS_HOSTNAME: ${INGRESS_HOSTNAME:-argocd}
+      INGRESS_DOMAIN: ${INGRESS_DOMAIN:-platform.sthings-vsphere.labul.sva.de}
+      INGRESS_SECRET_NAME: ${INGRESS_SECRET_NAME:-argocd-server-tls}
+      ISSUER_NAME: ${ISSUER_NAME:-vault-pki}
+      ISSUER_KIND: ${ISSUER_KIND:-ClusterIssuer}
+      ARGO_CD_PASSWORD_MTIME: ${ARGO_CD_PASSWORD_MTIME:-2026-03-23T02:00:00UTC}
+      AVP_TRUST_BUNDLE_CONFIGMAP: ${AVP_TRUST_BUNDLE_CONFIGMAP:-cluster-trust-bundle}
+      AVP_TRUST_BUNDLE_KEY: ${AVP_TRUST_BUNDLE_KEY:-trust-bundle.pem}
+      AVP_SSL_CERT_DIR: ${AVP_SSL_CERT_DIR:-/etc/ssl/custom}
+    substituteFrom:
+      - kind: Secret
+        name: ${ARGO_CD_SECRETS_NAME:-argocd-secrets}
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: argocd-deployment
+      namespace: ${ARGO_CD_NAMESPACE:-argocd}

--- a/cicd/argocd-platform/ks-argocd-config.yaml
+++ b/cicd/argocd-platform/ks-argocd-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ${BUNDLE_NAME:-argocd-platform}-argocd-config
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: argocd
+spec:
+  # Needs the Argo CD CRDs (AppProject / ApplicationSet) to exist first.
+  dependsOn:
+    - name: ${BUNDLE_NAME:-argocd-platform}-argo-cd
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: ${FLUX_SOURCE:-apps-upstream}
+  path: ./cicd/argocd-platform/config
+  prune: true
+  wait: true

--- a/cicd/argocd-platform/ks-clusterbook-operator.yaml
+++ b/cicd/argocd-platform/ks-clusterbook-operator.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ${BUNDLE_NAME:-argocd-platform}-clusterbook-operator
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/managed-by: flux
+    kustomization.stuttgart-things.com/type: app
+spec:
+  # Wait for Argo CD to be healthy before installing the operator: the operator
+  # writes Argo CD cluster-secrets and reads the argocd namespace.
+  dependsOn:
+    - name: ${BUNDLE_NAME:-argocd-platform}-argo-cd
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: ${FLUX_SOURCE:-apps-upstream}
+  path: ./apps/clusterbook-operator
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      CLUSTERBOOK_OPERATOR_NAMESPACE: ${CLUSTERBOOK_OPERATOR_NAMESPACE:-clusterbook-system}
+      CLUSTERBOOK_OPERATOR_VERSION: ${CLUSTERBOOK_OPERATOR_VERSION:-v0.19.0}

--- a/cicd/argocd-platform/kustomization.yaml
+++ b/cicd/argocd-platform/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+# argocd-platform bundle
+#
+# A consumer creates ONE Flux Kustomization pointing at ./cicd/argocd-platform
+# and gets the whole Argo CD platform, correctly ordered via dependsOn:
+#
+#   argo-cd (HelmRelease)
+#     └─> clusterbook-operator   (registers downstream clusters + stamps labels)
+#     └─> argocd-config          (AppProjects + cluster-generator ApplicationSet)
+#
+# The three resources below are themselves Flux Kustomization CRs that point
+# back at existing bases in this repo. When the parent (consumer) Kustomization
+# builds, Flux substitutes ${VAR:-default} into the child CR text, so each child
+# ends up with concrete postBuild.substitute values.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ks-argo-cd.yaml
+  - ks-clusterbook-operator.yaml
+  - ks-argocd-config.yaml


### PR DESCRIPTION
## What

Adds a self-contained **argocd-platform bundle** at `cicd/argocd-platform/` — a single Flux `Kustomization` entrypoint that deploys Argo CD, the clusterbook-operator, and reusable Argo CD config as three `dependsOn`-ordered child Kustomizations:

```
argocd-platform-argo-cd            → ./cicd/argo-cd            (HelmRelease)
  ├─ argocd-platform-clusterbook-operator   → ./apps/clusterbook-operator   (dependsOn argo-cd)
  └─ argocd-platform-argocd-config          → ./cicd/argocd-platform/config (dependsOn argo-cd)
```

## Why

A consumer points one Kustomization at `./cicd/argocd-platform` (with a `postBuild.substitute` block) and gets the whole Argo CD platform, correctly ordered — no CRD races, no duplicated bases. Templated with `${FLUX_SOURCE}` / `${BUNDLE_NAME}` so it is fleet-generic and multiple isolated copies can coexist.

## Design notes

- Reuses existing bases (`cicd/argo-cd`, `apps/clusterbook-operator`) — no duplication.
- `dependsOn` guarantees Argo CD is healthy before the operator or any Argo CD CR (AppProject/ApplicationSet) applies.
- Reusable config (`appset-cluster-projects`, `proj-cicd`) is **copied** in; originals in the clusters repo left untouched.
- Per-cluster data (`ClusterbookCluster` CRs, platform selection) intentionally stays in the consumer repo.

## Validation

`kustomize build cicd/argocd-platform` and `.../config` both produce expected resources; all `${VAR}` placeholders pass through kustomize and resolve at Flux apply time.

> Status: **bundle only**, no cluster wires it yet. The reference cluster (`platform-sthings`) is left as-is; the bundle will be tested on a separate cluster first. The clusters-repo README in this bundle shows the consumer-side usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)