### PR TITLE
fix(argocd-platform): quote substitute values in ks-argo-cd

### DIFF
--- a/cicd/argocd-platform/base/ks-argo-cd.yaml
+++ b/cicd/argocd-platform/base/ks-argo-cd.yaml
@@ -19,18 +19,18 @@ spec:
   wait: true
   postBuild:
     substitute:
-      ARGO_CD_VERSION: ${ARGO_CD_VERSION:-9.4.15}
-      ARGO_CD_NAMESPACE: ${ARGO_CD_NAMESPACE:-argocd}
-      ARGO_CD_INGRESS_ENABLED: ${ARGO_CD_INGRESS_ENABLED:-false}
-      INGRESS_HOSTNAME: ${INGRESS_HOSTNAME:-argocd}
-      INGRESS_DOMAIN: ${INGRESS_DOMAIN:-platform.sthings-vsphere.labul.sva.de}
-      INGRESS_SECRET_NAME: ${INGRESS_SECRET_NAME:-argocd-server-tls}
-      ISSUER_NAME: ${ISSUER_NAME:-vault-pki}
-      ISSUER_KIND: ${ISSUER_KIND:-ClusterIssuer}
-      ARGO_CD_PASSWORD_MTIME: ${ARGO_CD_PASSWORD_MTIME:-2026-03-23T02:00:00UTC}
-      AVP_TRUST_BUNDLE_CONFIGMAP: ${AVP_TRUST_BUNDLE_CONFIGMAP:-cluster-trust-bundle}
-      AVP_TRUST_BUNDLE_KEY: ${AVP_TRUST_BUNDLE_KEY:-trust-bundle.pem}
-      AVP_SSL_CERT_DIR: ${AVP_SSL_CERT_DIR:-/etc/ssl/custom}
+      ARGO_CD_VERSION: "${ARGO_CD_VERSION:-9.4.15}"
+      ARGO_CD_NAMESPACE: "${ARGO_CD_NAMESPACE:-argocd}"
+      ARGO_CD_INGRESS_ENABLED: "${ARGO_CD_INGRESS_ENABLED:-false}"
+      INGRESS_HOSTNAME: "${INGRESS_HOSTNAME:-argocd}"
+      INGRESS_DOMAIN: "${INGRESS_DOMAIN:-platform.sthings-vsphere.labul.sva.de}"
+      INGRESS_SECRET_NAME: "${INGRESS_SECRET_NAME:-argocd-server-tls}" # pragma: allowlist secret
+      ISSUER_NAME: "${ISSUER_NAME:-vault-pki}"
+      ISSUER_KIND: "${ISSUER_KIND:-ClusterIssuer}"
+      ARGO_CD_PASSWORD_MTIME: "${ARGO_CD_PASSWORD_MTIME:-2026-03-23T02:00:00UTC}" # pragma: allowlist secret
+      AVP_TRUST_BUNDLE_CONFIGMAP: "${AVP_TRUST_BUNDLE_CONFIGMAP:-cluster-trust-bundle}"
+      AVP_TRUST_BUNDLE_KEY: "${AVP_TRUST_BUNDLE_KEY:-trust-bundle.pem}"
+      AVP_SSL_CERT_DIR: "${AVP_SSL_CERT_DIR:-/etc/ssl/custom}"
     substituteFrom:
       - kind: Secret
         name: ${ARGO_CD_SECRETS_NAME:-argocd-secrets}


### PR DESCRIPTION
## Quote substitute values in argocd-platform `ks-argo-cd`

Flux `postBuild.substitute` is a `map[string]string`. In the bundle's `base/ks-argo-cd.yaml` the values were unquoted, so `ARGO_CD_INGRESS_ENABLED: ${ARGO_CD_INGRESS_ENABLED:-false}` rendered as a YAML **boolean** in the generated child Kustomization CR, failing the typed dry-run for any consumer of the bundle:

```
Kustomization/flux-system/argocd-platform-argo-cd dry-run failed:
  .spec.postBuild.substitute.ARGO_CD_INGRESS_ENABLED: expected string, got false
```

Wrapping every substitute value in quotes keeps them strings regardless of value (booleans, version-like, date-like). This unblocks the first real consumer of `cicd/argocd-platform` (the harvester platform cluster).

No behavioral change for string-valued vars; just type-correctness.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_