### PR TITLE
fix: stop semantic-release asset-name collision in .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -21,19 +21,11 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    [
-      "@semantic-release/github",
-      {
-        "assets": [
-          "dist/**/*.{go,mod,sum}",
-          "docs/**/*.{pdf,md}"
-        ]
-      }
-    ],
+    "@semantic-release/github",
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "go.mod", "go.sum"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
## What

Removes the release-asset config that broke the `v1.13.0` publish step.

## Root cause

`@semantic-release/github` had:
```json
"assets": ["dist/**/*.{go,mod,sum}", "docs/**/*.{pdf,md}"]
```
- `docs/**/*.md` matches **four `index.md`** files (`docs/`, `docs/apps/`, `docs/cicd/`, `docs/infra/`). GitHub names release assets by **basename**, so the second `index.md` upload failed with `ReleaseAsset already_exists` — aborting the publish step.
- `dist/**/*.{go,mod,sum}` matched nothing (no `dist/`), and the `@semantic-release/git` `go.mod`/`go.sum` assets don't exist either — all leftovers from a Go-project template.

## Fix

- Drop the `github` `assets` (releases keep their generated notes; globbed source docs aren't useful release artifacts and live in the repo + mkdocs site).
- Trim `git` assets to `CHANGELOG.md`.

Any glob over a docs tree with per-folder `index.md` would re-collide, so removal is the robust fix rather than narrowing the glob.

## Validation

`.releaserc` is valid JSON; `npx semantic-release --dry-run` loads all plugins cleanly with no asset step.

> Note: `v1.13.0` itself already tagged successfully — only the cosmetic asset upload failed. This prevents the non-zero exit on future `task release` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
