### PR TITLE
fix(argocd-platform): drop boolean ARGO_CD_INGRESS_ENABLED from nested substitute

### DIFF
--- a/cicd/argocd-platform/base/ks-argo-cd.yaml
+++ b/cicd/argocd-platform/base/ks-argo-cd.yaml
@@ -21,7 +21,12 @@ spec:
     substitute:
       ARGO_CD_VERSION: "${ARGO_CD_VERSION:-9.4.15}"
       ARGO_CD_NAMESPACE: "${ARGO_CD_NAMESPACE:-argocd}"
-      ARGO_CD_INGRESS_ENABLED: "${ARGO_CD_INGRESS_ENABLED:-false}"
+      # ARGO_CD_INGRESS_ENABLED is intentionally NOT threaded here. A bare
+      # boolean cannot survive a nested Kustomization substitute: kustomize
+      # build drops the quotes around ${VAR}, envsubst then yields a YAML bool,
+      # and Flux rejects it (postBuild.substitute is map[string]string).
+      # cicd/argo-cd defaults ingress off via ${ARGO_CD_INGRESS_ENABLED:-false}
+      # in its HelmRelease values, where a boolean is valid.
       INGRESS_HOSTNAME: "${INGRESS_HOSTNAME:-argocd}"
       INGRESS_DOMAIN: "${INGRESS_DOMAIN:-platform.sthings-vsphere.labul.sva.de}"
       INGRESS_SECRET_NAME: "${INGRESS_SECRET_NAME:-argocd-server-tls}" # pragma: allowlist secret


### PR DESCRIPTION
## Fix: don't thread a boolean through the nested Kustomization substitute

Follow-up to #159. Quoting `ARGO_CD_INGRESS_ENABLED` in `base/ks-argo-cd.yaml` doesn't actually fix it: `kustomize build` strips the quotes around `${VAR}`, so `envsubst` still renders a bare YAML boolean in the generated child Kustomization CR, and Flux rejects it because `postBuild.substitute` is a `map[string]string`:

```
Kustomization/flux-system/argocd-platform-argo-cd dry-run failed:
  .spec.postBuild.substitute.ARGO_CD_INGRESS_ENABLED: expected string, got false
```

**Fix:** remove `ARGO_CD_INGRESS_ENABLED` from this child's substitute map entirely. `cicd/argo-cd` already defaults ingress off via `${ARGO_CD_INGRESS_ENABLED:-false}` in its **HelmRelease values** (where a boolean is perfectly valid — it's not a string map). The bundle is gateway/HTTPRoute-based, so ingress stays disabled.

Verified as the blocker on the first real consumer (harvester platform). The other substitute values are strings and unaffected.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_