### PR TITLE
feat(clusterbook-operator): add parameterized providerconfig base

### DIFF
--- a/apps/clusterbook-operator/providerconfig/README.md
+++ b/apps/clusterbook-operator/providerconfig/README.md
@@ -1,0 +1,42 @@
+# clusterbook-operator / providerconfig
+
+Parameterized base for a cluster-scoped `ClusterbookProviderConfig`. Point a
+Flux `Kustomization` at `./apps/clusterbook-operator/providerconfig` and supply
+the backend via `postBuild.substitute`:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: clusterbook-providerconfig
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: clusterbook-operator   # ensure the CRD exists first
+  sourceRef:
+    kind: GitRepository
+    name: flux-apps
+  path: ./apps/clusterbook-operator/providerconfig
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      CLUSTERBOOK_PROVIDERCONFIG_NAME: default
+      CLUSTERBOOK_API_URL: https://clusterbook.infra.example.com
+      CLUSTERBOOK_INSECURE_SKIP_VERIFY: "false"
+```
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CLUSTERBOOK_PROVIDERCONFIG_NAME` | `default` | Name of the ProviderConfig (referenced by `ClusterbookCluster.spec.providerConfigRef`) |
+| `CLUSTERBOOK_API_URL` | *(required)* | Clusterbook backend URL (e.g. `https://clusterbook.infra.sthings.lab`) |
+| `CLUSTERBOOK_INSECURE_SKIP_VERIFY` | `false` | Skip TLS verification of the backend. Keep `false` and ensure the backend CA is in the operator's trust bundle; set `true` only if that CA can't be trusted. |
+
+> TLS: with `insecureSkipVerify: false` the operator verifies the backend cert
+> against the mounted `cluster-trust-bundle` (trust-manager). If the backend's
+> CA isn't in that bundle, either add it or set `CLUSTERBOOK_INSECURE_SKIP_VERIFY: "true"`.

--- a/apps/clusterbook-operator/providerconfig/kustomization.yaml
+++ b/apps/clusterbook-operator/providerconfig/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - providerconfig.yaml

--- a/apps/clusterbook-operator/providerconfig/providerconfig.yaml
+++ b/apps/clusterbook-operator/providerconfig/providerconfig.yaml
@@ -1,0 +1,13 @@
+---
+# Parameterized ClusterbookProviderConfig (cluster-scoped). The env-specific
+# apiURL is supplied by the consumer Flux Kustomization via postBuild.substitute
+# (e.g. clusters/<env>/clusterbook-providerconfig.yaml), keeping this base
+# generic. insecureSkipVerify is a real boolean field in the CRD, so the
+# substituted bare value is valid as-is.
+apiVersion: clusterbook.stuttgart-things.com/v1alpha1
+kind: ClusterbookProviderConfig
+metadata:
+  name: ${CLUSTERBOOK_PROVIDERCONFIG_NAME:-default}
+spec:
+  apiURL: ${CLUSTERBOOK_API_URL}
+  insecureSkipVerify: ${CLUSTERBOOK_INSECURE_SKIP_VERIFY:-false}


### PR DESCRIPTION
## Parameterized ClusterbookProviderConfig base

Adds a generic base at `apps/clusterbook-operator/providerconfig/` so consumers can manage the (cluster-scoped) `ClusterbookProviderConfig` via a Flux Kustomization with `postBuild.substitute`, keeping the environment-specific backend URL in the cluster config instead of a hardcoded manifest.

```yaml
spec:
  apiURL: ${CLUSTERBOOK_API_URL}
  insecureSkipVerify: ${CLUSTERBOOK_INSECURE_SKIP_VERIFY:-false}
```

`insecureSkipVerify` is a real boolean field in the CRD spec (not a Flux substitute map), so the substituted bare value is valid as-is. Consumed like:

```yaml
postBuild:
  substitute:
    CLUSTERBOOK_API_URL: https://clusterbook.infra.sthings.lab
    CLUSTERBOOK_INSECURE_SKIP_VERIFY: "false"
```

First consumer: the harvester platform cluster.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_