### PR TITLE
feat(argocd-platform): bundle ClusterbookProviderConfig (substitutable)

### DIFF
--- a/cicd/argocd-platform/base/clusterbook-providerconfig.yaml
+++ b/cicd/argocd-platform/base/clusterbook-providerconfig.yaml
@@ -1,0 +1,22 @@
+---
+# Cluster-scoped ClusterbookProviderConfig, applied DIRECTLY by the consumer
+# (parent) Kustomization as a raw resource in base/ — NOT via the nested
+# ks-argocd-config child. That one-hop path is deliberate: insecureSkipVerify
+# is a boolean, and routing a bare boolean through a child Kustomization's
+# postBuild.substitute (map[string]string) breaks (kustomize drops the quotes
+# -> Flux rejects the typed bool). Applied directly, the substituted value
+# lands in the CRD's real boolean field, so both apiURL and insecureSkipVerify
+# are cleanly substitutable.
+#
+# Seed-once: prune/reconcile disabled so Flux plants it and the operator owns
+# runtime/status afterward.
+apiVersion: clusterbook.stuttgart-things.com/v1alpha1
+kind: ClusterbookProviderConfig
+metadata:
+  name: default
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/reconcile: disabled
+spec:
+  apiURL: ${CLUSTERBOOK_API_URL}
+  insecureSkipVerify: ${CLUSTERBOOK_INSECURE_SKIP_VERIFY:-false}

--- a/cicd/argocd-platform/base/kustomization.yaml
+++ b/cicd/argocd-platform/base/kustomization.yaml
@@ -8,13 +8,16 @@
 #     └─> clusterbook-operator   (registers downstream clusters + stamps labels)
 #     └─> argocd-config          (AppProjects + cluster-generator ApplicationSet)
 #
-# The three resources below are themselves Flux Kustomization CRs that point
-# back at existing bases in this repo. When the parent (consumer) Kustomization
-# builds, Flux substitutes ${VAR:-default} into the child CR text, so each child
-# ends up with concrete postBuild.substitute values.
+# ks-*.yaml are Flux Kustomization CRs that point back at existing bases in this
+# repo; the consumer's substitute fills their ${VAR:-default} values.
+#
+# clusterbook-providerconfig.yaml is a RAW resource (not a child Kustomization)
+# so the consumer substitutes it one-hop and its boolean insecureSkipVerify
+# field works (see the file's header for why).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ks-argo-cd.yaml
   - ks-clusterbook-operator.yaml
   - ks-argocd-config.yaml
+  - clusterbook-providerconfig.yaml


### PR DESCRIPTION
## Bundle the ClusterbookProviderConfig (substitutable apiURL + insecureSkipVerify)

Adds the cluster-scoped `ClusterbookProviderConfig` to the argocd-platform bundle so deploying the bundle also seeds the clusterbook backend wiring.

### Files
- `base/clusterbook-providerconfig.yaml` — `name: default`, seed annotations (`prune`/`reconcile: disabled`), `apiURL: ${CLUSTERBOOK_API_URL}`, `insecureSkipVerify: ${CLUSTERBOOK_INSECURE_SKIP_VERIFY:-false}`.
- `base/kustomization.yaml` — adds it to `resources`.

### Why a raw resource (not in `base/config` via `ks-argocd-config`)
`insecureSkipVerify` is a **boolean**. Routing it through a nested child Kustomization's `postBuild.substitute` (a `map[string]string`) breaks — `kustomize build` strips the quotes and Flux rejects `expected string, got false` (the same bug fixed for `ARGO_CD_INGRESS_ENABLED` in #161). Applied as a **raw resource in `base/`**, the consumer substitutes it **one-hop**, so the value lands in the CRD's real boolean field and **both** `apiURL` and `insecureSkipVerify` are cleanly substitutable.

### Consumer usage
```yaml
postBuild:
  substitute:
    CLUSTERBOOK_API_URL: https://clusterbook.infra.sthings.lab
    CLUSTERBOOK_INSECURE_SKIP_VERIFY: "false"
```

Supersedes the standalone `apps/clusterbook-operator/providerconfig` consumption on the harvester cluster (that base remains, now redundant). First consumer: harvester platform.

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_