### PR TITLE
fix(backstage): use bundled PostgreSQL instead of better-sqlite3

### DIFF
--- a/apps/backstage/pre-release.yaml
+++ b/apps/backstage/pre-release.yaml
@@ -48,8 +48,12 @@ spec:
               methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
               credentials: true
             database:
-              client: better-sqlite3
-              connection: ':memory:'
+              client: pg
+              connection:
+                host: $${POSTGRES_HOST}
+                port: $${POSTGRES_PORT:-5432}
+                user: $${POSTGRES_USER}
+                password: $${POSTGRES_PASSWORD}
           integrations:
             github:
               - host: github.com

--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -107,6 +107,20 @@ spec:
             secretKeyRef:
               name: backstage-secrets
               key: EXTERNAL_ACCESS_TOKEN
+        # PostgreSQL connection for the backend database (client: pg). The
+        # bundled postgresql subchart is named <release>-postgresql; its Secret
+        # holds the backstage user's password under key "password".
+        - name: POSTGRES_HOST
+          value: backstage-deployment-postgresql
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_USER
+          value: backstage
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: backstage-deployment-postgresql
+              key: password
       extraAppConfig:
         - filename: app-config.extra.yaml
           configMapRef: backstage-app-config


### PR DESCRIPTION
## Backstage: use the bundled PostgreSQL instead of better-sqlite3

The app-config hardcoded:
```yaml
backend:
  database:
    client: better-sqlite3
    connection: ':memory:'
```
But the `sthings-backstage` image (Node 24) ships **no `better-sqlite3` native bindings**, so every backend plugin failed at init:
```
Could not locate the bindings file … better-sqlite3 … node-v137-linux-x64/better_sqlite3.node
```
→ backend never becomes ready → readiness 503 → gateway returns **"no healthy upstream"**. Meanwhile the chart already deploys a healthy PostgreSQL (`<release>-postgresql`, `postgresql.enabled: true`) that was being ignored.

### Fix
- **`pre-release.yaml`** — backend database → `client: pg`, connection from `$${POSTGRES_HOST/PORT/USER/PASSWORD}` (Backstage runtime env substitution, hence `$$`).
- **`release.yaml`** — inject those env vars into the backstage container:
  - `POSTGRES_HOST: backstage-deployment-postgresql`, `POSTGRES_PORT: "5432"`, `POSTGRES_USER: backstage`
  - `POSTGRES_PASSWORD` from secret `backstage-deployment-postgresql` key `password` (the bundled subchart's secret)

Now Backstage persists to PostgreSQL (the in-memory SQLite was also non-persistent) and starts cleanly. Affects all consumers of `apps/backstage`.

### After merge (harvester)
```bash
flux reconcile source git flux-apps -n flux-system
flux reconcile kustomization flux-system --with-source
flux reconcile hr backstage-configuration -n backstage --force   # re-render the configmap (pg)
flux reconcile hr backstage-deployment   -n backstage --force
kubectl -n backstage rollout restart deploy/backstage-deployment
kubectl -n backstage get pods            # backstage 1/1 Ready
```

https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa

---
_Generated by [Claude Code](https://claude.ai/code/session_014x4LVcwkrq73KDcKWLb8Wa)_