### PR TITLE
fix(backstage): drop duplicate POSTGRES_* env vars

### DIFF
--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -107,20 +107,6 @@ spec:
             secretKeyRef:
               name: backstage-secrets
               key: EXTERNAL_ACCESS_TOKEN
-        # PostgreSQL connection for the backend database (client: pg). The
-        # bundled postgresql subchart is named <release>-postgresql; its Secret
-        # holds the backstage user's password under key "password".
-        - name: POSTGRES_HOST
-          value: backstage-deployment-postgresql
-        - name: POSTGRES_PORT
-          value: "5432"
-        - name: POSTGRES_USER
-          value: backstage
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: backstage-deployment-postgresql
-              key: password
       extraAppConfig:
         - filename: app-config.extra.yaml
           configMapRef: backstage-app-config


### PR DESCRIPTION
The official backstage chart (v2.6.3) already injects POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER and POSTGRES_PASSWORD into the backstage container whenever postgresql.enabled is true. The manual copies in extraEnvVars produced duplicate entries in the container env list-map, which server-side apply rejects -> HelmRelease stalled (RetriesExceeded).

The chart-injected values are identical (host backstage-deployment-postgresql, port 5432, user backstage, password from the <release>-postgresql secret key 'password'), so removing the manual block keeps the same DB connection.