### PR TITLE
feat: add argocd-platform overlays (network-only + sthings-lab)

### DIFF
--- a/cicd/argocd-platform/overlays/network/kustomization.yaml
+++ b/cicd/argocd-platform/overlays/network/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+# Example overlay: the bundle base + ONLY the network catalog platform.
+#
+# Opt-in model: the base (argo-cd + clusterbook-operator + config) carries NO
+# platforms. This overlay enables just `components/network`, which adds one
+# dependsOn-ordered Flux Kustomization pointing at the argocd-catalog source's
+# ./platforms/network — i.e. it preinstalls the nine *-clusterbook
+# ApplicationSets onto the management cluster.
+#
+# Requirements on the target cluster:
+#   * the `argocd-catalog` GitRepository source (${ARGOCD_CATALOG_SOURCE})
+#     pointing at https://github.com/stuttgart-things/argocd.git
+#   * the `argocd-secrets` Secret in flux-system (consumed by cicd/argo-cd)
+#
+# The AppSets stay dormant until a ClusterbookCluster causes the operator to
+# stamp a cluster Secret with `network-platform: "true"` + the allocation-ip
+# label, so enabling this overlay on a cluster with no labeled clusters is
+# harmless.
+#
+# Point your consumer Flux Kustomization at this path, e.g.
+#   path: ./cicd/argocd-platform/overlays/network
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../components/network

--- a/cicd/argocd-platform/overlays/sthings-lab/kustomization.yaml
+++ b/cicd/argocd-platform/overlays/sthings-lab/kustomization.yaml
@@ -25,3 +25,4 @@ components:
   - ../../components/cicd       # cicd platform stack
   - ../../components/security   # security platform stack
   - ../../components/storage    # storage platform stack
+  - ../../components/kind       # kind platform stack

--- a/cicd/argocd-platform/overlays/sthings-lab/kustomization.yaml
+++ b/cicd/argocd-platform/overlays/sthings-lab/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+# Per-cluster overlay: sthings-lab
+#
+# This file IS the platform on/off switch for the sthings-lab management
+# cluster. The component list below is the declarative selection — add a line
+# to enable a catalog platform, delete it to disable (and Flux prunes whatever
+# that platform deployed, because the resource leaves the kustomize build).
+#
+# Consume it by pointing ONE Flux Kustomization at this path:
+#   path: ./cicd/argocd-platform/overlays/sthings-lab
+# (keep your existing postBuild.substitute block; add ARGOCD_CATALOG_SOURCE and
+# ensure the argocd-catalog GitRepository source exists in flux-system).
+#
+# Each component adds one dependsOn-ordered Flux Kustomization pointing at the
+# argocd-catalog source's ./platforms/<name>, preinstalling that platform's
+# clusterbook ApplicationSets. They stay dormant until clusterbook-operator
+# labels a cluster Secret (e.g. network-platform: "true" + allocation-ip), so
+# an enabled-but-unlabeled platform matches zero clusters and is harmless.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+components:
+  - ../../components/network   # cilium LB/gateway + cert-manager chain + trust-manager
+  - ../../components/cicd       # cicd platform stack
+  - ../../components/security   # security platform stack
+  - ../../components/storage    # storage platform stack


### PR DESCRIPTION
## What

Adds two consumable `argocd-platform` overlays so a cluster can enable catalog platforms by pointing one Flux `Kustomization` at an overlay path, instead of running the platform-free `base`:

- `cicd/argocd-platform/overlays/network/` — base + `components/network` only (the nine `*-clusterbook` ApplicationSets).
- `cicd/argocd-platform/overlays/sthings-lab/` — per-cluster overlay enabling `network`, `cicd`, `security`, and `storage`. The component list is the declarative on/off switch.

## Why

The base deliberately carries no platforms, so a consumer on `path: ./cicd/argocd-platform/base` gets only `cluster-projects` + `proj-cicd` and no platform AppSets. These overlays make platform selection a single `path:` change while keeping correct kustomize composition + Flux pruning (removing a component prunes whatever that platform deployed — which a `spec.suspend`-via-var toggle could not do).

## Consuming

Point the consumer Kustomization at an overlay and provide the catalog source:

```yaml
spec:
  path: ./cicd/argocd-platform/overlays/sthings-lab
  postBuild:
    substitute:
      ARGOCD_CATALOG_SOURCE: argocd-catalog
```

Requires the `argocd-catalog` `GitRepository` (url `https://github.com/stuttgart-things/argocd.git`) in `flux-system`. The AppSets stay dormant until clusterbook-operator labels a cluster Secret (`network-platform: "true"` + `allocation-ip`, plus `auto-project: "true"` for the per-cluster AppProject).

## Notes

- Both overlays reuse the existing `base` + `components/*` pattern (same relative paths as `overlays/full`); no existing files changed.
- Consumer-side wiring (the `argocd-platform` Kustomization, the `argocd-catalog` source, `ClusterbookCluster` CRs) lives in the cluster config repo, not here.

https://claude.ai/code/session_0183zeU9fk8yZskEgzXUa7Db

---
_Generated by [Claude Code](https://claude.ai/code/session_0183zeU9fk8yZskEgzXUa7Db)_