### PR TITLE
feat(claim-machinery-api): opt into Stakater Reloader for ConfigMap/Secret changes

### DIFF
--- a/apps/claim-machinery-api/release.yaml
+++ b/apps/claim-machinery-api/release.yaml
@@ -42,6 +42,20 @@ spec:
                   image: ghcr.io/stuttgart-things/claim-machinery-api:${CLAIM_MACHINERY_API_VERSION:-v0.21.1}
                   args:
                     - server
+    # Opt into Stakater Reloader so a change to the claim-machinery-api
+    # ConfigMap/Secret (e.g. TEMPLATE_PROFILE_PATH) auto-rolls the Deployment.
+    # NOTE: only fires on ConfigMap/Secret changes, not on edits to the
+    # remote profile YAMLs (those are fetched by URL at runtime).
+    - target:
+        kind: Deployment
+        name: claim-machinery-api
+      patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: claim-machinery-api
+          annotations:
+            reloader.stakater.com/auto: "${CLAIM_MACHINERY_RELOADER_AUTO:-true}"
     # Override TEMPLATE_PROFILE_PATH and configure homerun2 notifications
     - target:
         kind: ConfigMap


### PR DESCRIPTION
## What

Annotate the `claim-machinery-api` Deployment with `reloader.stakater.com/auto`
so a change to its ConfigMap/Secret (notably `TEMPLATE_PROFILE_PATH`) triggers an
automatic rolling restart instead of requiring a manual `kubectl rollout restart`.

Gated by a new substitution var `CLAIM_MACHINERY_RELOADER_AUTO` (default `"true"`)
so individual clusters can opt out.

## Why

Today, when a cluster overlay changes the profile path (e.g. adding a second
profile to the colon-separated `TEMPLATE_PROFILE_PATH`), Flux updates the
ConfigMap but the running pod keeps serving the old profile set until manually
restarted. Stakater Reloader is already deployed cluster-wide on platform-sthings
(`infra/reloader.yaml`), so this just opts the workload in.

## Caveats

- Only fires on **ConfigMap/Secret** changes, not on edits to the **remote
  profile YAMLs** themselves — those are fetched by URL at runtime, so reloader
  cannot observe them.
- Requires Stakater Reloader to be running in the target cluster (already true on
  platform-sthings; no-op annotation otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)