### PR TITLE
feat(infra): add prometheus-pve-exporter app

### DIFF
--- a/infra/prometheus-pve-exporter/README.md
+++ b/infra/prometheus-pve-exporter/README.md
@@ -1,0 +1,31 @@
+# prometheus-pve-exporter
+
+Pull-based Proxmox VE monitoring. The kube-prometheus-stack Prometheus scrapes
+[`prometheus-pve-exporter`](https://github.com/prometheus-pve/prometheus-pve-exporter)
+at `/pve?target=<host>`; the exporter queries the Proxmox API **read-only** and
+returns cluster, node, guest and storage metrics. A Grafana dashboard is shipped
+as a ConfigMap and auto-imported by the kps Grafana sidecar.
+
+## Resources
+
+| File | Purpose |
+|------|---------|
+| `deployment.yaml` | exporter (non-root, read-only rootfs); credentials via `envFrom` secret `prometheus-pve-exporter` |
+| `service.yaml` | ClusterIP `:9221` (debugging / port-forward) |
+| `podmonitor.yaml` | scrape config; labelled `app.kubernetes.io/component: monitoring` to match the kps `podMonitorSelector` |
+| `dashboard.json` | Grafana dashboard (ConfigMap label `grafana_dashboard: "1"`) |
+
+## Required substitutions (Flux `postBuild.substitute`)
+
+Set by the consuming `Kustomization` in the cluster repo:
+
+| Variable | Example | Meaning |
+|----------|---------|---------|
+| `PVE_EXPORTER_VERSION` | `3.9.0` | container image tag |
+| `PVE_EXPORTER_TARGET` | `ul-pve01.labul.sva.de` | Proxmox host scraped via `?target=` |
+
+## Required secret
+
+A `Secret/prometheus-pve-exporter` (namespace `monitoring`) with keys
+`PVE_USER`, `PVE_TOKEN_NAME`, `PVE_TOKEN_VALUE` — a read-only PVE API token
+(role `PVEAuditor`). Provided SOPS-encrypted from the cluster repo.

--- a/infra/prometheus-pve-exporter/dashboard.json
+++ b/infra/prometheus-pve-exporter/dashboard.json
@@ -1,0 +1,91 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["proxmox", "pve", "infrastructure"],
+  "title": "Proxmox VE",
+  "uid": "proxmox-pve-exporter",
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "label": "Datasource"
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(pve_node_info, id)",
+        "includeAll": true,
+        "multi": true,
+        "refresh": 2,
+        "label": "Node"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "1m",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Nodes Online",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } } },
+      "targets": [ { "expr": "count(pve_up{id=~\"node/.*\"} == 1)", "refId": "A" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Guests Running",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "targets": [ { "expr": "count(pve_up{id=~\"qemu/.*\"} == 1)", "refId": "A" } ]
+    },
+    {
+      "type": "stat",
+      "title": "Guests Stopped",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 1 } ] } } },
+      "targets": [ { "expr": "count(pve_up{id=~\"qemu/.*\"} == 0) or vector(0)", "refId": "A" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Node CPU Usage",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [ { "expr": "pve_cpu_usage_ratio{id=~\"node/.*\", id=~\"$node\"}", "legendFormat": "{{id}}", "refId": "A" } ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Node Memory Usage %",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [ { "expr": "pve_memory_usage_bytes{id=~\"node/.*\", id=~\"$node\"} / pve_memory_size_bytes{id=~\"node/.*\", id=~\"$node\"}", "legendFormat": "{{id}}", "refId": "A" } ]
+    },
+    {
+      "type": "bargauge",
+      "title": "Storage Usage %",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 0.75 }, { "color": "red", "value": 0.85 } ] } } },
+      "options": { "orientation": "horizontal", "displayMode": "gradient" },
+      "targets": [ { "expr": "pve_disk_usage_bytes{id=~\"storage/.*\"} / pve_disk_size_bytes{id=~\"storage/.*\"}", "legendFormat": "{{id}}", "refId": "A" } ]
+    },
+    {
+      "type": "table",
+      "title": "Guests",
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [ { "expr": "pve_guest_info", "format": "table", "instant": true, "refId": "A" } ],
+      "transformations": [ { "id": "organize", "options": { "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true, "instance": true } } } ]
+    }
+  ]
+}

--- a/infra/prometheus-pve-exporter/deployment.yaml
+++ b/infra/prometheus-pve-exporter/deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-pve-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus-pve-exporter
+    app.kubernetes.io/part-of: kube-prometheus-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-pve-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus-pve-exporter
+        app.kubernetes.io/part-of: kube-prometheus-stack
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: pve-exporter
+          image: prompve/prometheus-pve-exporter:${PVE_EXPORTER_VERSION}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9221
+              protocol: TCP
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          env:
+            # Target Proxmox host is supplied per-scrape via the ?target= param
+            # set in the PodMonitor (pull model); credentials come from the
+            # SOPS-encrypted secret applied at cluster level.
+            - name: PVE_VERIFY_SSL
+              value: "false"
+          envFrom:
+            - secretRef:
+                name: prometheus-pve-exporter
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15

--- a/infra/prometheus-pve-exporter/kustomization.yaml
+++ b/infra/prometheus-pve-exporter/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - deployment.yaml
+  - service.yaml
+  - podmonitor.yaml
+configMapGenerator:
+  # Picked up automatically by the kube-prometheus-stack Grafana sidecar,
+  # which imports any ConfigMap labelled grafana_dashboard.
+  - name: pve-exporter-dashboard
+    files:
+      - proxmox-pve.json=dashboard.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+        app.kubernetes.io/part-of: kube-prometheus-stack
+generatorOptions:
+  disableNameSuffixHash: false

--- a/infra/prometheus-pve-exporter/podmonitor.yaml
+++ b/infra/prometheus-pve-exporter/podmonitor.yaml
@@ -1,0 +1,37 @@
+---
+# Pull model: kube-prometheus-stack's Prometheus is configured with
+#   podMonitorSelector: { app.kubernetes.io/component: monitoring }
+#   podMonitorNamespaceSelector: {}
+# so this PodMonitor (carrying that label) is auto-discovered and Prometheus
+# scrapes the exporter at /pve?target=<PVE host>. The exporter then queries the
+# Proxmox API read-only and returns cluster/node/guest/storage metrics.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: prometheus-pve-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus-pve-exporter
+    app.kubernetes.io/component: monitoring
+    app.kubernetes.io/part-of: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-pve-exporter
+  podMetricsEndpoints:
+    - port: http
+      path: /pve
+      interval: 60s
+      scrapeTimeout: 30s
+      params:
+        target:
+          - ${PVE_EXPORTER_TARGET}
+        cluster:
+          - "1"
+        node:
+          - "1"
+      relabelings:
+        # Expose the scraped Proxmox host as the `instance` label instead of the
+        # exporter pod IP, so dashboards group by the actual PVE endpoint.
+        - sourceLabels: [__param_target]
+          targetLabel: instance

--- a/infra/prometheus-pve-exporter/service.yaml
+++ b/infra/prometheus-pve-exporter/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-pve-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus-pve-exporter
+    app.kubernetes.io/part-of: kube-prometheus-stack
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: prometheus-pve-exporter
+  ports:
+    - name: http
+      port: 9221
+      targetPort: http
+      protocol: TCP


### PR DESCRIPTION
## What

Adds `infra/prometheus-pve-exporter/` — pull-based Proxmox VE monitoring consumed by clusters through the `flux-infra` source.

kube-prometheus-stack's Prometheus scrapes the exporter at `/pve?target=<host>`; the exporter queries the Proxmox API **read-only** and returns cluster/node/guest/storage metrics. A Grafana dashboard is shipped as a ConfigMap and auto-imported by the kps sidecar.

## Contents

- `deployment.yaml` (image via `${PVE_EXPORTER_VERSION}`, non-root, read-only rootfs)
- `service.yaml` (ClusterIP :9221)
- `podmonitor.yaml` (label `app.kubernetes.io/component: monitoring` → matches kps `podMonitorSelector`; target via `${PVE_EXPORTER_TARGET}`)
- `dashboard.json` + configMapGenerator (`grafana_dashboard: "1"`)
- `README.md`

## Consumption

A consuming cluster `Kustomization` (in the cluster repo) sets `postBuild.substitute` for `PVE_EXPORTER_VERSION` / `PVE_EXPORTER_TARGET` and provides the SOPS-encrypted `Secret/prometheus-pve-exporter` (read-only `PVEAuditor` token).

Validated with `kustomize build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)