### PR TITLE
fix(ci): static job name for OCI push matrix job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,11 @@ jobs:
           echo "${components}" | jq -r '.[]'
 
   push:
-    name: push ${{ matrix.component }}
+    # NB: keep this a static string — referencing ${{ matrix.component }} in a
+    # job-level name fails at startup when the matrix is derived from `needs`
+    # (the graph is built before `needs` resolves). GitHub already appends the
+    # matrix value to each job's display name.
+    name: push OCI artifact
     needs: plan
     if: needs.plan.outputs.components != '[]'
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Release` workflow from #176 failed at **startup** on merge to main (`startup_failure`, 0 jobs) — no static linter (actionlint / JSON-schema) catches it.

**Cause:** the `push` job used a job-level `name: push ${{ matrix.component }}`. When the matrix is derived from `needs` (dynamic), GitHub must render the job name while building the job graph — before `needs` resolves — which is impossible, so the whole run fails to start.

**Fix:** static job name. GitHub still appends the matrix value to each job's display name, so per-component runs stay distinguishable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)