### PR TITLE
docs: document OCI artifact publishing & consumption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,20 @@ Uses Angular commit convention for semantic-release (configured in `.releaserc`)
 
 Tags follow `v${version}` format (e.g., `v1.3.0`).
 
+## Release & OCI Artifact Publishing
+
+The `Release` workflow (`.github/workflows/release.yaml`) runs on every push to `main`:
+
+1. **release** – semantic-release cuts the SemVer tag + GitHub Release and updates `CHANGELOG.md`. Releases now happen in CI — do **not** run `task release` locally as well (it would race on the tag/CHANGELOG).
+2. **plan** – resolves the version tag (new release version, else the latest existing tag) and diffs the merge to find changed `apps/*` / `infra/*` components.
+3. **push** – packages each **changed** component as a Flux OCI artifact via `flux push artifact`.
+
+- **Naming:** `oci://ghcr.io/stuttgart-things/flux/<apps|infra>/<name>` (e.g. `flux/apps/vault`)
+- **Tags:** the release version (e.g. `v1.17.0`) **and** the rolling `latest`
+- Only changed components get the new version tag; unchanged components keep their existing tags (content — and therefore `latest` — is unchanged). Consumers reference an artifact via `OCIRepository` instead of `GitRepository` (see README → OCI ARTIFACTS).
+
+Note: the workflow uses third-party actions (semantic-release, flux2). The `stuttgart-things` org restricts non-first-party actions — an unlisted one fails the run with `startup_failure` (0 jobs, no logs) despite passing actionlint; the fix is org-side allowlisting, not a code change.
+
 ## SOPS Secrets Encryption
 
 Encrypt/decrypt secrets using Dagger SOPS module with Age keys:

--- a/README.md
+++ b/README.md
@@ -262,6 +262,57 @@ metadata:
 
 </details>
 
+## OCI ARTIFACTS
+
+On every merge to `main` the `Release` workflow (`.github/workflows/release.yaml`)
+cuts a SemVer tag via semantic-release and publishes each **changed** `apps/*`
+and `infra/*` component as a Flux OCI artifact to ghcr.io. This lets consumers
+point an `OCIRepository` at a versioned artifact instead of a `GitRepository`.
+
+* **Naming:** `oci://ghcr.io/stuttgart-things/flux/<apps|infra>/<name>`
+  (e.g. `flux/apps/vault`, `flux/infra/cert-manager`)
+* **Tags:** the release version (e.g. `v1.17.0`) **and** the rolling `latest`
+* Only changed components get the new version tag; unchanged components keep
+  their existing tags (their content — and therefore `latest` — is unchanged)
+
+<details><summary>CONSUME AS OCIREPOSITORY</summary>
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vault
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things/flux/apps/vault
+  ref:
+    tag: v1.17.0   # or: latest
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vault
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: OCIRepository
+    name: vault
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      VAULT_NAMESPACE: vault
+EOF
+```
+
+</details>
+
 ## DEV
 
 <details><summary>GENERATE KUST</summary>


### PR DESCRIPTION
Documents the OCI artifact pipeline added in #176:

- **README** → new `## OCI ARTIFACTS` section: naming scheme, tagging, and a collapsible `OCIRepository` + `Kustomization` consumption example.
- **CLAUDE.md** → new `## Release & OCI Artifact Publishing` section: the three-job Release workflow, the "releases run in CI now (don't `task release` locally)" caveat, and the org-actions-allowlist `startup_failure` gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)