### PR TITLE
fix(ci): run OCI push despite skipped release on manual dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,7 +145,10 @@ jobs:
     # matrix value to each job's display name.
     name: push OCI artifact
     needs: plan
-    if: needs.plan.outputs.components != '[]'
+    # !cancelled() is required: on manual dispatch the skipped `release` job
+    # propagates a skip through `plan` to this job under the default success()
+    # gate. Explicitly gate on plan succeeding + a non-empty component list.
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.components != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The  backfill (#184) produced an empty push matrix: the skipped `release` job propagated a transitive skip through `plan` to `push` under the default `success()` gate. Confirmed via probe jobs — a `!cancelled()` job saw `plan.result=success` and the full 40-component array, while a default-gated job skipped.

**Fix:** gate `push` on `!cancelled() && needs.plan.result == 'success' && needs.plan.outputs.components != '[]'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)