### PR TITLE
docs: manual OCI backfill + renovate fileMatch fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,15 @@ The `Release` workflow (`.github/workflows/release.yaml`) runs on every push to 
 - **Tags:** the release version (e.g. `v1.17.0`) **and** the rolling `latest`
 - Only changed components get the new version tag; unchanged components keep their existing tags (content — and therefore `latest` — is unchanged). Consumers reference an artifact via `OCIRepository` instead of `GitRepository` (see README → OCI ARTIFACTS).
 
+**Manual backfill / re-push:** the workflow also has a `workflow_dispatch` trigger with a `push-all` boolean input (default `true`). Running it publishes **all** `apps/*` and `infra/*` components at the current release version — used to seed the registry or force a re-push. On manual dispatch the `release` job is skipped (no new tag is cut); the version tag is taken from the latest existing git tag.
+
+```bash
+gh workflow run release.yaml --ref main -f push-all=true    # backfill everything
+gh workflow run release.yaml --ref main -f push-all=false   # changed-only (rarely useful manually)
+```
+
+Note: because `release` is skipped on manual dispatch, the `push` job is gated on `!cancelled() && needs.plan.result == 'success'` — otherwise the skipped `release` would propagate a transitive skip through `plan` and yield an empty push matrix.
+
 Note: the workflow uses third-party actions (semantic-release, flux2). The `stuttgart-things` org restricts non-first-party actions — an unlisted one fails the run with `startup_failure` (0 jobs, no logs) despite passing actionlint; the fix is org-side allowlisting, not a code change.
 
 ## SOPS Secrets Encryption

--- a/README.md
+++ b/README.md
@@ -313,6 +313,20 @@ EOF
 
 </details>
 
+<details><summary>BACKFILL / RE-PUSH ALL ARTIFACTS (manual)</summary>
+
+The workflow has a `workflow_dispatch` trigger with a `push-all` input (default
+`true`) that publishes **all** components at the current release version — for
+seeding the registry or forcing a re-push. No new release is cut on manual
+dispatch; the version tag is taken from the latest existing git tag.
+
+```bash
+# Push every apps/* and infra/* component (backfill)
+gh workflow run release.yaml --ref main -f push-all=true
+```
+
+</details>
+
 ## DEV
 
 <details><summary>GENERATE KUST</summary>

--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,16 @@
   "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 10,
   "flux": {
-    "managerFilePatterns": [
-      "/\\.yaml$/"
+    "fileMatch": [
+      "\\.yaml$"
     ]
   },
   "customManagers": [
     {
       "customType": "regex",
       "description": "Update default values in Flux variable substitution OCI refs like ref.tag: ${VAR:-v1.2.3}",
-      "managerFilePatterns": [
-        "/\\.yaml$/"
+      "fileMatch": [
+        "\\.yaml$"
       ],
       "matchStrings": [
         "url:\\s*oci://(?<depName>[^\\s]+)\\s*\\n\\s*ref:\\s*\\n\\s*tag:\\s*\\$\\{[A-Z_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
@@ -27,8 +27,8 @@
     {
       "customType": "regex",
       "description": "Update default image tags in Flux patches like image: ghcr.io/org/app:${VAR:-v1.2.3}",
-      "managerFilePatterns": [
-        "/\\.yaml$/"
+      "fileMatch": [
+        "\\.yaml$"
       ],
       "matchStrings": [
         "image:\\s*(?<depName>[^:$\\s]+):\\$\\{[A-Z_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"


### PR DESCRIPTION
Documents the manual `workflow_dispatch` backfill trigger (README + CLAUDE.md) and reverts the Renovate file-matching field.

**Renovate:** `managerFilePatterns` is only recognised by Renovate v41+; `fileMatch` validates on all versions including latest v43 (verified with `renovate-config-validator`). Reverting to `fileMatch` is the maximally compatible choice and matches this repo original config. All other improvements (config:recommended, minimumReleaseAge, prConcurrentLimit, packageRules, the two Flux `${VAR:-default}` custom managers) are unchanged.

Generated with Claude Code