### PR TITLE
fix: unbreak openebs upgrades, hook image is gone from docker.io

### DIFF
--- a/infra/openebs/README.md
+++ b/infra/openebs/README.md
@@ -43,7 +43,7 @@ spec:
   wait: true
   postBuild:
     substitute:
-      VERSION: 4.2.0
+      OPENEBS_VERSION: 4.2.0
       VOLUMESNAPSHOTS_ENABLED: "false"
       CSI_NODE_INIT_CONTAINERS_ENABLED: "false"
       LOCAL_LVM_ENABLED: "false"

--- a/infra/openebs/release.yaml
+++ b/infra/openebs/release.yaml
@@ -16,6 +16,16 @@ spec:
         namespace: ${OPENEBS_NAMESPACE:-openebs}
       interval: 12h
   values:
+    # The chart defaults this hook to docker.io/bitnami/kubectl:1.25.15, which
+    # Bitnami has removed from the registry — the pull fails with NotFound, the
+    # pre-upgrade hook never completes, and every helm upgrade of this release
+    # times out. Use the upstream Kubernetes kubectl image instead, which is
+    # also far closer to the clusters' API version than 1.25.
+    preUpgradeHook:
+      image:
+        registry: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REGISTRY:-registry.k8s.io}
+        repo: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REPO:-kubectl}
+        tag: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_TAG:-v1.34.0}
     openebs-crds:
       csi:
         volumeSnapshots:


### PR DESCRIPTION
## Problem

The openebs chart defaults its pre-upgrade hook to `docker.io/bitnami/kubectl:1.25.15`. **Bitnami has removed that image** — only signature/metadata tags remain under `bitnami/kubectl`:

```
Failed to pull image "docker.io/bitnami/kubectl:1.25.15":
  failed to resolve reference: docker.io/bitnami/kubectl:1.25.15: not found
```

The hook job therefore never completes and **every helm upgrade of this release times out**:

```
Helm upgrade failed for release openebs/openebs with chart openebs@4.2.0:
  pre-upgrade hooks failed: timeout waiting for:
  [Job/openebs/openebs-pre-upgrade-hook status: 'InProgress']
```

Witnessed on `platform-sthings` on 2026-07-22, where it blocked recovery of a crashlooping `openebs-localpv-provisioner` (its ClusterRole/ClusterRoleBinding had gone missing; a reconcile was the natural fix and could not complete). The RBAC was restored out of band, but the HelmRelease is still stuck at `Ready=False`.

This affects **any** cluster consuming `./infra/openebs` — the failure is dormant until something triggers an upgrade.

## Change

Point the hook at the upstream Kubernetes kubectl image, wired through substitution variables in the usual house style:

```yaml
preUpgradeHook:
  image:
    registry: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REGISTRY:-registry.k8s.io}
    repo: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REPO:-kubectl}
    tag: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_TAG:-v1.34.0}
```

Beyond simply existing, `v1.34` is within the supported version skew of our 1.35 clusters — `1.25` is ten minor versions behind, and the hook runs `kubectl` against the live API.

Verified that the chart renders the intended reference:

```
$ helm template ... --set preUpgradeHook.image.registry=registry.k8s.io \
    --set preUpgradeHook.image.repo=kubectl --set preUpgradeHook.image.tag=v1.34.0
  - name: pre-upgrade-job
    image: registry.k8s.io/kubectl:v1.34.0
```

and that `registry.k8s.io/kubectl:v1.34.0` resolves (HTTP 200 on the manifest).

## Second fix: a substitution that silently did nothing

`README.md` documented the version knob as `VERSION`, but `release.yaml` reads `${OPENEBS_VERSION:-4.2.0}`. Consumers copied `VERSION` from the README, so **bumping it had no effect** — it only looked correct because the default happens to be the same value. Both known consumers (`platform-sthings`, `infra-sthings`) set `VERSION: '4.2.0'` today.

Every other component under `infra/` uses the `<COMPONENT>_VERSION` convention, so `release.yaml` was right and the README was wrong. Fixed the README.

**Follow-up outside this repo:** the two consumer `openebs.yaml` files in `stuttgart-things/stuttgart-things` still substitute `VERSION` and should be changed to `OPENEBS_VERSION`. It is a no-op today (both resolve to 4.2.0), but the next version bump would silently do nothing. Those files are generated from a `template: openebs` claim, so the claim-machinery template likely carries the same mistake and should be checked.

## Rollout note

Consumers pin `flux-infra` by tag. `platform-sthings` is currently on `v1.16.0`, so it needs a pin bump after this is tagged. The only other functional change between `v1.16.0` and `v1.18.1` is a velero AWS plugin patch bump (`1.14.1` → `1.14.2`), which that cluster does use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ
