### PR TITLE
fix: openebs hook image must ship a shell, not just kubectl

### DIFF
--- a/infra/openebs/release.yaml
+++ b/infra/openebs/release.yaml
@@ -19,13 +19,18 @@ spec:
     # The chart defaults this hook to docker.io/bitnami/kubectl:1.25.15, which
     # Bitnami has removed from the registry — the pull fails with NotFound, the
     # pre-upgrade hook never completes, and every helm upgrade of this release
-    # times out. Use the upstream Kubernetes kubectl image instead, which is
-    # also far closer to the clusters' API version than 1.25.
+    # times out.
+    #
+    # The replacement must ship a shell: the chart invokes the hook with
+    # command: ["/bin/sh","-c"], so a distroless image such as
+    # registry.k8s.io/kubectl pulls fine but dies with
+    # 'exec: "/bin/sh": no such file or directory'. alpine/kubectl has one, and
+    # 1.35 matches the clusters' API version.
     preUpgradeHook:
       image:
-        registry: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REGISTRY:-registry.k8s.io}
-        repo: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REPO:-kubectl}
-        tag: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_TAG:-v1.34.0}
+        registry: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REGISTRY:-docker.io}
+        repo: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_REPO:-alpine/kubectl}
+        tag: ${OPENEBS_PREUPGRADE_HOOK_IMAGE_TAG:-1.35.4}
     openebs-crds:
       csi:
         volumeSnapshots:


### PR DESCRIPTION
Follow-up to #188 — that fix was incomplete.

## What #188 got wrong

#188 repointed the openebs pre-upgrade hook from the removed `docker.io/bitnami/kubectl:1.25.15` to `registry.k8s.io/kubectl:v1.34.0`. That image exists and pulls fine — `ImagePullBackOff` is gone — but it is **distroless**, and the chart invokes the hook as:

```yaml
command: ["/bin/sh", "-c"]
args: ["(kubectl annotate --overwrite crd ... || true) && (kubectl -n openebs delete deploy ...)"]
```

So the container dies before running anything:

```
StartError, exitCode 128
failed to create containerd task: OCI runtime create failed:
  unable to start container process: error during container init:
  exec: "/bin/sh": stat /bin/sh: no such file or directory
```

The hook still never completes and helm upgrades still time out — same symptom as before, different cause. I verified that the image existed and that the chart rendered the intended reference, but not that it satisfied how the chart *invokes* it.

## Fix

`alpine/kubectl:1.35.4` — Alpine-based, so it ships `/bin/sh`, and 1.35 matches the clusters' API version (1.35.1) exactly rather than being ten minors behind like the original 1.25.

Verified this time by actually running the image in-cluster with the same shape the chart uses, rather than by inspection:

```
$ kubectl run imgtest --image=alpine/kubectl:1.35.4 --command -- \
    /bin/sh -c 'echo "shell ok"; kubectl version --client'
phase=Succeeded
shell ok
Client Version: v1.35.4
Kustomize Version: v5.7.1
```

and that the chart renders the intended reference:

```
- name: pre-upgrade-job
  image: docker.io/alpine/kubectl:1.35.4
```

The substitution variables are unchanged, so anyone overriding them is unaffected.

## Note for reviewers

The lesson worth keeping: for this hook, image availability is not the requirement — **shell availability** is. Any future replacement has to satisfy `command: ["/bin/sh","-c"]`, which rules out the distroless upstream images that would otherwise be the natural choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ
