### PR TITLE
fix(openebs): disarm the observability stack before it can arrive

### DIFF
--- a/infra/openebs/README.md
+++ b/infra/openebs/README.md
@@ -46,11 +46,40 @@ spec:
       OPENEBS_VERSION: 4.2.0
       VOLUMESNAPSHOTS_ENABLED: "false"
       CSI_NODE_INIT_CONTAINERS_ENABLED: "false"
+      LOCAL_HOSTPATH_ENABLED: "true"
       LOCAL_LVM_ENABLED: "false"
       LOCAL_ZFS_ENABLED: "false"
       REPLICATED_MAYASTOR_ENABLED: "false"
+      OPENEBS_LOKI_ENABLED: "false"
+      OPENEBS_ALLOY_ENABLED: "false"
 EOF
 ```
+
+## Before raising `OPENEBS_VERSION`
+
+The chart changed shape between 4.2 and 4.5, in two ways that are invisible from
+the value list:
+
+| | 4.2.0 | 4.5.x |
+|---|---|---|
+| `loki` / `alloy` | not dependencies at all | `loki 6.29.0` and `alloy 1.0.1`, **both default true** |
+| `localpv-provisioner` | unconditional | `condition: engines.local.hostpath.enabled` |
+
+So a bare version bump would deploy a Loki StatefulSet, the MinIO StatefulSet
+backing it (MinIO is Loki's object store — a sub-dependency with no toggle of
+its own), an Alloy DaemonSet and two extra StorageClasses. On a small cluster
+Loki cannot even schedule: it wants three replicas with pod anti-affinity.
+
+`release.yaml` therefore sets `loki.enabled`, `alloy.enabled` and
+`engines.local.hostpath.enabled` explicitly, even though the first two are
+no-ops at 4.2.0. The chart ships no `values.schema.json`, so the unknown keys
+are accepted rather than rejected — verified against both versions.
+
+One more asymmetry worth knowing: the `preUpgradeHook` image override above is
+needed at 4.2.0, whose default is the **removed** `docker.io/bitnami/kubectl`.
+4.5.x defaults to `docker.io/openebs/kubectl` and no longer needs it. The
+override is harmless either way, since `alpine/kubectl` ships the shell the
+hook's `command: ["/bin/sh","-c"]` requires.
 
 ## Claims CLI
 

--- a/infra/openebs/release.yaml
+++ b/infra/openebs/release.yaml
@@ -40,8 +40,43 @@ spec:
         node:
           initContainers:
             enabled: ${CSI_NODE_INIT_CONTAINERS_ENABLED:-false}
+    # AN OBSERVABILITY STACK NOBODY ASKED FOR, disarmed BEFORE it can arrive.
+    #
+    # These two keys do nothing at the pinned 4.2.0 — that chart has no such
+    # dependencies at all, and its values.yaml does not mention loki, minio or
+    # alloy once. They are here for the version bump, because OPENEBS_VERSION is
+    # substitutable and 4.5.x added:
+    #
+    #   loki   6.29.0   condition: loki.enabled    (default TRUE)
+    #   alloy  1.0.1    condition: alloy.enabled   (default TRUE)
+    #
+    # So raising the version alone would silently deploy a Loki StatefulSet, the
+    # MinIO StatefulSet backing it (MinIO is Loki's object store — a
+    # sub-dependency with no toggle of its own), an Alloy log-shipper DaemonSet
+    # and two extra StorageClasses, onto every cluster consuming this artifact.
+    # Without these lines the artifact would offer no way to say no.
+    #
+    # On a small cluster it is worse than noise: Loki asks for three replicas
+    # with pod anti-affinity, so on a 1+2 node cluster replica 0 sits Pending
+    # forever. openebs-hostpath — the StorageClass this fleet actually uses — is
+    # unaffected either way.
+    #
+    # Harmless at 4.2.0: the chart ships no values.schema.json, so unknown keys
+    # are accepted rather than rejected. Verified against both 4.2.0 and 4.5.1.
+    loki:
+      enabled: ${OPENEBS_LOKI_ENABLED:-false}
+    alloy:
+      enabled: ${OPENEBS_ALLOY_ENABLED:-false}
     engines:
       local:
+        # STATED, NOT INHERITED, and for the same reason as the two above. At
+        # 4.2.0 localpv-provisioner is an unconditional dependency; at 4.5.x it
+        # gained `condition: engines.local.hostpath.enabled`. That is the
+        # provisioner behind openebs-hostpath, i.e. the only reason this fleet
+        # installs openebs at all — so it should not depend on an upstream
+        # default staying true across a bump.
+        hostpath:
+          enabled: ${LOCAL_HOSTPATH_ENABLED:-true}
         lvm:
           enabled: ${LOCAL_LVM_ENABLED:-false}
         zfs:


### PR DESCRIPTION
`OPENEBS_VERSION` is substitutable, and the chart **changed shape** between 4.2 and 4.5 in ways no value list reveals:

| | 4.2.0 | 4.5.1 |
|---|---|---|
| `loki` | not a dependency | `6.29.0`, `condition: loki.enabled`, **default true** |
| `alloy` | not a dependency | `1.0.1`, `condition: alloy.enabled`, **default true** |
| `localpv-provisioner` | unconditional | `condition: engines.local.hostpath.enabled` |

At the pinned 4.2.0 none of that exists — `helm show values openebs/openebs --version 4.2.0` does not mention loki, minio or alloy **once**.

So a bare version bump would silently deploy a Loki StatefulSet, the **MinIO StatefulSet backing it** (MinIO is Loki's object store — a sub-dependency with no toggle of its own), an Alloy log-shipper DaemonSet and two extra StorageClasses onto every cluster consuming this artifact. And the artifact offered **no way to say no**, because it had no such keys.

On a small cluster that is worse than noise: Loki asks for three replicas with pod anti-affinity, so on a 1+2 node cluster replica 0 sits `Pending` forever.

## `hostpath` is stated for the mirror-image reason

`localpv-provisioner` is what provides `openebs-hostpath` — the only StorageClass this fleet actually uses. After 4.5 it hangs off an upstream default staying `true`. That is not something the one reason we install openebs should depend on.

## Safe at 4.2.0

All three keys are no-ops there, and accepted rather than rejected: the chart ships **no `values.schema.json`** — verified against both 4.2.0 and 4.5.1.

## README

Gains the 4.2-vs-4.5 table, and the note that the `preUpgradeHook` override is a **4.2-only** need: 4.2.0 defaults to the *removed* `docker.io/bitnami/kubectl`, while 4.5.x defaults to `docker.io/openebs/kubectl`. The override stays harmless either way, since `alpine/kubectl` ships the shell the hook's `command: ["/bin/sh","-c"]` requires.

## Why now

This artifact is the next entry going into the `xplane-flux-catalog`, so a `Platform` XR will soon be able to set `OPENEBS_VERSION` from a one-line spec field. Better that the trap is closed before that path exists than after someone finds it.
