### PR TITLE
fix(apps/machinery): v-prefixed version default, and ship the watch-set

### DIFF
--- a/apps/machinery/README.md
+++ b/apps/machinery/README.md
@@ -25,7 +25,7 @@ spec:
   postBuild:
     substitute:
       MACHINERY_NAMESPACE: machinery
-      MACHINERY_VERSION: latest
+      MACHINERY_VERSION: v1.13.4
       MACHINERY_HOSTNAME: machinery
       GATEWAY_NAME: movie-scripts2-gateway
       GATEWAY_NAMESPACE: default
@@ -38,11 +38,30 @@ EOF
 | Variable | Default | Description |
 |---|---|---|
 | `MACHINERY_NAMESPACE` | `machinery` | Target namespace |
-| `MACHINERY_VERSION` | `latest` | Image + kustomize OCI tag |
+| `MACHINERY_VERSION` | `v1.13.4` | Image + kustomize OCI tag — **keep the `v`** |
 | `MACHINERY_HOSTNAME` | `machinery` | HTTPRoute hostname prefix |
 | `GATEWAY_NAME` | *(required)* | Gateway API gateway name |
 | `GATEWAY_NAMESPACE` | `default` | Gateway namespace |
 | `DOMAIN` | *(required)* | Domain suffix for HTTPRoute hostname |
+
+Both `ghcr.io/stuttgart-things/machinery` and `ghcr.io/stuttgart-things/machinery-kustomize` publish `v`-prefixed tags, so one variable serves both — but only in that form. A bare `1.13.4` leaves the `OCIRepository` unresolvable, and the resulting error does not mention the version, so the app simply never deploys.
+
+## What the dashboard watches
+
+The kinds and fields come from `config.json` in the `machinery-watch-config` ConfigMap ([`watch-config.yaml`](watch-config.yaml)), mounted at `/etc/machinery` and pointed to by `MACHINERY_CONFIG`. It ships this fleet's XRs:
+
+| kind | shown |
+|---|---|
+| `ClusterStack` | `status.stage` — the one field to look at when a build is stuck — plus endpoint, domain and IP |
+| `Platform` | `readyComponents` / `componentCount`, so `3 / 4` is visible without opening the YAML |
+| `XIPReservation` | reservation status, FQDN, addresses |
+| `VaultK8sAuth` | Vault address and cluster (its status is empty today, so Ready comes from conditions) |
+
+The file is deliberately **not** a substitution variable: it is one document, identical on every cluster here, and threading ~60 lines of JSON through `postBuild.substitute` would mean escaping it across newlines for nothing. To watch something else, patch the ConfigMap.
+
+It is also deliberately **not** called `machinery-config`. That name belongs to the Kustomize base, which feeds it to the container through `envFrom` — a `config.json` key there would additionally be offered as an environment variable, and `config.json` is not a valid environment variable name.
+
+Field paths are verified against a live cluster rather than read off the XRD schemas. Note that the renderer does not support array indexing (`spec.parentRefs[0].name`); point at the parent path and let it flatten.
 
 ## Endpoints
 

--- a/apps/machinery/kustomization.yaml
+++ b/apps/machinery/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - requirements.yaml
   - release.yaml
+  - watch-config.yaml
   - httproute.yaml

--- a/apps/machinery/release.yaml
+++ b/apps/machinery/release.yaml
@@ -29,7 +29,7 @@ spec:
             spec:
               containers:
                 - name: machinery
-                  image: ghcr.io/stuttgart-things/machinery:${MACHINERY_VERSION:-1.13.4}
+                  image: ghcr.io/stuttgart-things/machinery:${MACHINERY_VERSION:-v1.13.4}
     # Mount MACHINERY_CONFIG from ConfigMap as a file
     - target:
         kind: Deployment
@@ -54,7 +54,10 @@ spec:
               volumes:
                 - name: machinery-config
                   configMap:
-                    name: machinery-config
+                    # NOT `machinery-config` — that ConfigMap belongs to the
+                    # Kustomize base and is consumed via envFrom. See
+                    # watch-config.yaml.
+                    name: machinery-watch-config
                     optional: true
     # Add HTTP port to deployment
     - target:

--- a/apps/machinery/requirements.yaml
+++ b/apps/machinery/requirements.yaml
@@ -15,4 +15,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/machinery-kustomize
   ref:
-    tag: ${MACHINERY_VERSION:-1.13.4}
+    tag: ${MACHINERY_VERSION:-v1.13.4}

--- a/apps/machinery/watch-config.yaml
+++ b/apps/machinery/watch-config.yaml
@@ -1,0 +1,89 @@
+---
+# The watch-set: which kinds the dashboard shows, and which fields it reads.
+#
+# Shipped as a FILE rather than a substitution variable on purpose. The document
+# is ~60 lines of JSON and identical on every cluster in this fleet; threading it
+# through `postBuild.substitute` would mean escaping it across newlines for no
+# gain. Environments that need a different set override this ConfigMap with a
+# kustomize patch.
+#
+# NOT named `machinery-config`. That name is taken by the Kustomize base, which
+# feeds it to the container via `envFrom` — a `config.json` key there would also
+# be offered as an environment variable, and `config.json` is not a valid env
+# var name, so the kubelet skips it with a warning on every start.
+#
+# Field paths verified against a live cluster (u26-rke2-1 via kind3, 2026-08-15),
+# not derived from the XRD schemas. Array indexing is deliberately absent — the
+# renderer does not support it (examples/configs/README.md in
+# stuttgart-things/machinery); slice-valued paths are flattened instead.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machinery-watch-config
+  namespace: ${MACHINERY_NAMESPACE:-machinery}
+  labels:
+    app.kubernetes.io/name: machinery
+    app.kubernetes.io/part-of: stuttgart-things
+data:
+  config.json: |
+    {
+      "port": 50051,
+      "httpPort": 8080,
+      "resources": {
+        "ClusterStack": {
+          "group": "config.stuttgart-things.com",
+          "version": "v1alpha1",
+          "resource": "clusterstacks",
+          "connectionField": "status.share.apiEndpoint",
+          "statusFields": [
+            "status.stage",
+            "status.share.domain",
+            "status.share.ip"
+          ],
+          "infoFields": [
+            { "label": "Distribution", "path": "status.share.clusterType" },
+            { "label": "Version",      "path": "status.share.serverVersion" },
+            { "label": "CNI",          "path": "status.share.cniOwnership" },
+            { "label": "Provider",     "path": "spec.provider" }
+          ]
+        },
+        "Platform": {
+          "group": "config.stuttgart-things.com",
+          "version": "v1alpha1",
+          "resource": "platforms",
+          "statusFields": [
+            "status.readyComponents",
+            "status.componentCount"
+          ],
+          "infoFields": [
+            { "label": "Cluster",   "path": "status.shared.clusterName" },
+            { "label": "Type",      "path": "status.shared.clusterType" },
+            { "label": "Domain",    "path": "status.components.ipReservation.domain" },
+            { "label": "Namespace", "path": "status.shared.namespace" }
+          ]
+        },
+        "XIPReservation": {
+          "group": "resources.stuttgart-things.com",
+          "version": "v1alpha1",
+          "resource": "xipreservations",
+          "connectionField": "status.ipAddresses",
+          "statusFields": [
+            "status.reservationStatus",
+            "status.fqdn"
+          ],
+          "infoFields": [
+            { "label": "Zone",       "path": "status.zone" },
+            { "label": "NetworkKey", "path": "status.networkKey" }
+          ]
+        },
+        "VaultK8sAuth": {
+          "group": "config.stuttgart-things.com",
+          "version": "v1alpha1",
+          "resource": "vaultk8sauths",
+          "infoFields": [
+            { "label": "Vault",   "path": "spec.vaultAddr" },
+            { "label": "Cluster", "path": "spec.clusterName" }
+          ]
+        }
+      }
+    }


### PR DESCRIPTION
Behebt #193 — beide Punkte. Gefunden beim Aufnehmen der App in den Crossplane-Katalog (stuttgart-things/kcl#115); beide ließen die App „erfolgreich" deployen, ohne dass sie etwas Nützliches tut.

## 1. Der Version-Default nannte einen Tag, den es nicht gibt

`requirements.yaml` defaultete `MACHINERY_VERSION` auf `1.13.4`. Beide Pakete publizieren aber `v`-präfixierte Tags:

```
$ flux pull artifact oci://…/machinery-kustomize:1.13.4
✗ MANIFEST_UNKNOWN: manifest unknown
$ flux pull artifact oci://…/machinery-kustomize:v1.13.4
✔ artifact content extracted
```

`v1.13.4` ist das **aktuelle** Release, nicht veraltet — es fehlte wirklich nur das Präfix. Geprüft für beide Pakete: `machinery` und `machinery-kustomize` tragen dieselben `v`-Tags, eine Variable kann also weiterhin beide bedienen.

Der README behauptete zudem einen Default `latest`, den es nie gab.

## 2. `MACHINERY_CONFIG` zeigte auf eine Datei, die niemand lieferte

`release.yaml` patcht `MACHINERY_CONFIG=/etc/machinery/config.json` und mountet die ConfigMap `machinery-config` — die kommt aber aus der Kustomize-Basis und enthält nur `LOG_LEVEL`. Der Pfad hing in der Luft, der Dienst lief auf eingebauten Defaults, die `StoragePlatform` und `NetworkIntegration` beobachten. Ein Dashboard, nur nicht unseres.

Der Watch-Set kommt jetzt als **Datei** mit — `watch-config.yaml` → ConfigMap `machinery-watch-config` — und deckt `ClusterStack`, `Platform`, `XIPReservation`, `VaultK8sAuth` ab.

**Bewusst nicht `machinery-config` genannt.** Die Basis reicht diese ConfigMap per `envFrom` an den Container; ein `config.json`-Schlüssel darin würde zusätzlich als Umgebungsvariable angeboten — und `config.json` ist kein gültiger Env-Name, das Kubelet überspringt ihn bei jedem Start mit einer Warnung.

**Bewusst eine Datei statt einer Substitution.** Das Dokument ist ein einziges ~60-Zeilen-JSON, auf jedem Cluster dieser Fleet identisch; es über `postBuild.substitute` zu fädeln hieße, es über Zeilenumbrüche zu escapen — für nichts. Wer abweichen will, patcht die ConfigMap.

## Zwei korrigierte Feldpfade

Die Pfade sind gegen einen laufenden Cluster geprüft (u26-rke2-1 über kind3), nicht aus den XRD-Schemas abgeleitet. Das hat zwei Fehler im ursprünglichen Vorschlag aus stuttgart-things/machinery#93 aufgedeckt:

`status.shared` trägt **weder `domain` noch `apiEndpoint`**. Die Domain liegt unter `status.components.ipReservation.domain`, den Endpoint gibt es nur am `ClusterStack` als `status.share.apiEndpoint`. Beide hätten leere Spalten gerendert.

## Geprüft

- `kustomize build apps/machinery` → 5 Ressourcen, die ConfigMap landet im substituierten Namespace
- das eingebettete JSON ist valide und enthält die vier erwarteten Kinds
- keine Array-Indizierung, die der Renderer laut `examples/configs/README.md` nicht unterstützt

Closes #193