### PR TITLE
feat(release): publish cicd/* as OCI artifacts too

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,9 +111,9 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] \
              && [ "${{ inputs.push-all }}" = "true" ]; then
-            # Backfill: every apps/* and infra/* component directory.
+            # Backfill: every apps/*, infra/* and cicd/* component directory.
             components=$(
-              find apps infra -mindepth 1 -maxdepth 1 -type d \
+              find apps infra cicd -mindepth 1 -maxdepth 1 -type d \
                 | sort -u \
                 | jq -R -s -c 'split("\n") | map(select(length>0))'
             )
@@ -127,8 +127,8 @@ jobs:
             fi
             components=$(
               git diff --name-only "$base" "$head" \
-                | grep -E '^(apps|infra)/[^/]+/' \
-                | sed -E 's#^((apps|infra)/[^/]+)/.*#\1#' \
+                | grep -E '^(apps|infra|cicd)/[^/]+/' \
+                | sed -E 's#^((apps|infra|cicd)/[^/]+)/.*#\1#' \
                 | sort -u \
                 | jq -R -s -c 'split("\n") | map(select(length>0))'
             )


### PR DESCRIPTION
Der Workflow veröffentlichte `apps/*` und `infra/*` und sonst nichts — in beiden Pfaden, dem changed-only wie dem Backfill.

Die sieben Verzeichnisse unter `cicd/` (`tekton`, `argo-cd`, `argocd-platform`, `argo-rollouts`, `crossplane`, `komoplane`, `kro`) sind deshalb **nie veröffentlicht worden**:

```
41 Artefakte unter flux/apps und flux/infra
 0 unter flux/cicd
```

Die heutigen Konsumenten ziehen sie stattdessen über eine `GitRepository` — das funktioniert, stellt sie aber außerhalb des Modells, das alles andere benutzt.

## Warum es jetzt auffällt

Der `flux-apps`-Katalog kann sie **gar nicht** referenzieren: ein Katalog-Eintrag benennt ein `oci://`-Artefakt, und für `cicd/*` gibt es nichts zu benennen.

Aufgefallen beim Versuch, `tekton` in den Katalog aufzunehmen, damit ein Management-Cluster `AnsibleRun`s ausführen kann — ein AnsibleRun **ist** ein PipelineRun, ein Cluster ohne Tekton baut also eine VM und kann sie dann nicht fertigstellen.

Erster von drei PRs; die beiden folgenden betreffen die Struktur von `cicd/tekton` und den Katalog-Eintrag.