### PR TITLE
fix(tekton): disable Results by default, and stop feeding Triggers a value it rejects

### DIFF
--- a/cicd/tekton/README.md
+++ b/cicd/tekton/README.md
@@ -105,6 +105,44 @@ The TektonConfig `profile` controls which components the operator installs:
 | `basic` | Pipelines + Triggers |
 | `all` | Pipelines + Triggers + Dashboard |
 
+## Caveat: `profile: all` is not "everything you want"
+
+`all` installs Tekton **Results**, and Results brings a PostgreSQL StatefulSet.
+Two things follow, both seen on u26-rke2-1 on 2026-08-17:
+
+1. A cluster that only runs PipelineRuns gets a database nobody asked for.
+2. On a cluster with **no default StorageClass** the PVC stays `Pending`, the
+   operator blocks on Results, and nothing after it installs — including the
+   Dashboard, which is usually the reason `all` was chosen in the first place.
+
+The symptom is quiet: `TektonConfig` reports
+`Components not in ready state`, `TektonPipeline` and `TektonTrigger` are both
+`Ready=True`, and the Dashboard CR simply never appears.
+
+Results is therefore **disabled by default** (`TEKTON_RESULT_DISABLED`, default
+`true`) rather than dropping the profile to `basic` — `basic` also drops the
+Dashboard. Set it to `false` on a cluster that has a default StorageClass and
+wants a run archive.
+
+## Caveat: `enable-api-fields` and Triggers
+
+`TEKTON_ENABLE_API_FIELDS` defaults to `stable`, not `beta`.
+
+The operator propagates this value from `TektonConfig` to every component, and
+**Triggers accepts only `stable` or `alpha`**. With `beta` the operator writes
+it onto `TektonTrigger`, gets it coerced back, and requeues forever:
+
+```
+TektonConfig   Components not in ready state: TektonTrigger: reconcile again and proceed
+TektonTrigger  Ready=True   (all sub-conditions True, all three pods Running)
+```
+
+The loop never converges and blocks every component after Triggers. Restarting
+the operator does not clear it — the value does.
+
+A cluster that needs beta pipeline features can still set it, but then it needs
+`profile: basic` or an equivalent so Triggers is out of the picture.
+
 ## Caveat: Pruner + Crossplane-managed PipelineRuns
 
 The operator's pruner is a single cluster-wide CronJob (`tekton-pipelines/tekton-resource-pruner-*`) built from `TektonConfig.spec.pruner`. It iterates every namespace containing TaskRuns/PipelineRuns and deletes anything older than `keep-since`.

--- a/cicd/tekton/components/config/tekton-config.yaml
+++ b/cicd/tekton/components/config/tekton-config.yaml
@@ -6,8 +6,26 @@ metadata:
 spec:
   targetNamespace: ${TEKTON_TARGET_NAMESPACE:-tekton-pipelines}
   profile: ${TEKTON_PROFILE:-all}
+  # `all` installs Results too, and Results brings a PostgreSQL StatefulSet.
+  # A cluster that only runs PipelineRuns does not want a database, and on one
+  # without a DEFAULT StorageClass the PVC stays Pending, the operator blocks on
+  # it, and NOTHING after Results ever installs — including the Dashboard the
+  # `all` profile was chosen for. Observed on u26-rke2-1, 2026-08-17.
+  #
+  # Disabled by default rather than dropping the profile to `basic`, because
+  # `basic` also drops the Dashboard, and the Dashboard is the reason to run a
+  # profile above `lite` at all. Set TEKTON_RESULT_DISABLED=false on a cluster
+  # that has a default StorageClass and actually wants a run archive.
+  result:
+    disabled: ${TEKTON_RESULT_DISABLED:-true}
   pipeline:
-    enable-api-fields: ${TEKTON_ENABLE_API_FIELDS:-beta}
+    # NOT propagated to Triggers by us — the operator does that itself, and
+    # Triggers accepts only `stable` or `alpha`. Setting `beta` here makes the
+    # operator try to write `beta` onto TektonTrigger, get it coerced back, and
+    # requeue forever with "Components not in ready state: TektonTrigger:
+    # reconcile again and proceed" while TektonTrigger itself reports Ready.
+    # Same cluster, same day. Keep this in step with what Triggers can take.
+    enable-api-fields: ${TEKTON_ENABLE_API_FIELDS:-stable}
     disable-inline-spec: ${TEKTON_DISABLE_INLINE_SPEC:-""}
   pruner:
     disabled: ${TEKTON_PRUNER_DISABLED:-false}


### PR DESCRIPTION
Zwei unabhängige Defaults, die beide verhinderten, dass das Dashboard je installiert wurde. Am 17.08.2026 auf `u26-rke2-1` gefunden.

## 1. `profile: all` bringt Results — und damit eine PostgreSQL

Auf einem Cluster **ohne Default-StorageClass** bleibt deren PVC `Pending`, der Operator blockiert auf Results, und **nichts danach wird installiert** — einschließlich des Dashboards, für das man `all` überhaupt gewählt hatte.

Und ein Cluster, der nur PipelineRuns fährt, will keine Datenbank.

Deshalb `TEKTON_RESULT_DISABLED` mit Default `true`, statt auf `profile: basic` zu gehen — `basic` ließe auch das Dashboard fallen.

## 2. `enable-api-fields` von `beta` auf `stable`

Der Operator propagiert diesen Wert von der `TektonConfig` an **jede** Komponente, und **Triggers akzeptiert nur `stable` oder `alpha`**. Mit `beta` schreibt er ihn auf `TektonTrigger`, bekommt ihn zurückkorrigiert und requeued endlos:

```
TektonConfig   Components not in ready state: TektonTrigger: reconcile again and proceed
TektonTrigger  Ready=True   (alle Sub-Conditions True, alle drei Pods Running)
```

Ein Neustart des Operators räumt das **nicht** ab. Der Wert schon — nach der Änderung sprang die Meldung direkt zur nächsten Komponente weiter.

## Warum beides schwer zu finden ist

Keiner der beiden Fehler nennt seine Ursache, und beide zeigen sich als *„das Dashboard erscheint einfach nicht"*. Beide stehen jetzt mit den beobachteten Conditions im README, damit der nächste sie wiedererkennt.

Nach dem Fix: `TektonConfig` `Ready=True`, Dashboard-CR `v0.66.0`, Deployment `1/1`, HTTPS **200**.