### PR TITLE
fix(openebs): make openebs-hostpath the default StorageClass

### DIFF
--- a/infra/openebs/README.md
+++ b/infra/openebs/README.md
@@ -1,5 +1,34 @@
 # stuttgart-things/flux/infra/openebs
 
+## openebs-hostpath is the default StorageClass
+
+`localpv-provisioner.hostpathClass.isDefaultClass` defaults to **true** here,
+unlike the chart, which ships `false`.
+
+This app only ever lands on target clusters, and those are rke2 — which ships
+no default StorageClass at all. Without one, every PVC that does not name a
+class stays `Pending`:
+
+```
+FailedBinding  no persistent volumes available for this claim and no storage class is set
+```
+
+and the workload above it never starts.
+
+Found the expensive way on u26-rke2-1, 2026-08-17. Tekton's `all` profile
+installs Results, Results wants a PostgreSQL, its PVC hung, the Tekton operator
+blocked on it, and nothing after Results ever installed — including the
+Dashboard. Nothing in the visible failure named storage or a class; it
+presented as "the Dashboard never appeared".
+
+A cluster that installs openebs and leaves its StorageClass non-default has
+done half a job — openebs-hostpath is the reason this fleet installs openebs at
+all.
+
+**Set `OPENEBS_HOSTPATH_DEFAULT_CLASS=false` on a cluster that already has a
+default.** A kind target carries `standard` from the kind image, and two
+defaults is a misconfiguration the API server resolves arbitrarily.
+
 ## REQUIREMENTS
 
 <details><summary>ADD GITREPOSITORY</summary>

--- a/infra/openebs/release.yaml
+++ b/infra/openebs/release.yaml
@@ -67,6 +67,28 @@ spec:
       enabled: ${OPENEBS_LOKI_ENABLED:-false}
     alloy:
       enabled: ${OPENEBS_ALLOY_ENABLED:-false}
+    localpv-provisioner:
+      hostpathClass:
+        # DEFAULT true, unlike the chart. This app only ever lands on target
+        # clusters, and those are rke2 — which ships no default StorageClass at
+        # all. Without one every PVC that does not name a class stays Pending
+        # with "no persistent volumes available for this claim and no storage
+        # class is set", and the workload above it simply never starts.
+        #
+        # Found the expensive way on u26-rke2-1, 2026-08-17: Tekton's `all`
+        # profile installs Results, Results wants a PostgreSQL, its PVC hung,
+        # the Tekton operator blocked on it, and NOTHING after Results ever
+        # installed — including the Dashboard. The cause named neither storage
+        # nor a class; it presented as "the Dashboard never appeared".
+        #
+        # openebs-hostpath is the StorageClass this fleet actually uses, and it
+        # is the only reason openebs is installed. A cluster that installs it
+        # and then leaves it non-default has done half a job.
+        #
+        # Set false on a cluster that already HAS a default — a kind target
+        # carries `standard` from the kind image, and two defaults is a
+        # misconfiguration the API server resolves arbitrarily.
+        isDefaultClass: ${OPENEBS_HOSTPATH_DEFAULT_CLASS:-true}
     engines:
       local:
         # STATED, NOT INHERITED, and for the same reason as the two above. At


### PR DESCRIPTION
Der Chart liefert `isDefaultClass: false`. Diese App landet aber ausschließlich auf **Zielclustern**, und die sind rke2 — das **gar keine** Default-StorageClass mitbringt.

Jeder Cluster, der openebs installiert hatte, stand also weiterhin ohne Default da, und jede PVC ohne explizite Klasse blieb `Pending`:

```
FailedBinding  no persistent volumes available for this claim and
               no storage class is set
```

## Wie es aufgefallen ist

Auf `u26-rke2-1` am 17.08.2026, auf dem teuren Weg. Tektons `all`-Profil installiert Results, Results will eine PostgreSQL, deren PVC hing, der Tekton-Operator blockierte darauf — und **nichts nach Results** wurde je installiert, einschließlich des Dashboards.

Nichts am sichtbaren Fehler nannte Speicher oder eine Klasse. Es zeigte sich als „das Dashboard erscheint einfach nicht", und die Suche ging durch den Operator, seine Logs, einen Neustart und zwei Komponenten-CRs, bevor sie bei einer PVC ankam.

`openebs-hostpath` ist die StorageClass, die diese Fleet benutzt, und der einzige Grund, openebs überhaupt zu installieren. Sie zu installieren und nicht als Default zu markieren ist eine halbe Arbeit.

## Überschreibbar für den einen Fall, in dem es falsch ist

`OPENEBS_HOSTPATH_DEFAULT_CLASS=false` — ein kind-Ziel bringt bereits `standard` aus dem kind-Image mit, und zwei Defaults sind eine Fehlkonfiguration, die der API-Server willkürlich auflöst.

kind3 ist so oder so nicht betroffen: es hat gar kein Flux, sein openebs kommt aus dem machinery-Play.
