### PR TITLE
feat(sops-secrets-operator): a Flux app for the operator

### DIFF
--- a/apps/sops-secrets-operator/README.md
+++ b/apps/sops-secrets-operator/README.md
@@ -1,0 +1,75 @@
+# stuttgart-things/flux/apps/sops-secrets-operator
+
+Flux app for [sops-secrets-operator](https://github.com/stuttgart-things/sops-secrets-operator) —
+the operator that turns a `SopsSecret` (an age-encrypted blob committed to git)
+into a real Kubernetes `Secret`. Deploys the OCI kustomize base built from that
+repo's `config/default`.
+
+## Kustomization Example
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sops-secrets-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  sourceRef:
+    kind: OCIRepository
+    name: stuttgart-things-flux
+  path: ./apps/sops-secrets-operator
+  prune: true
+  wait: true
+  postBuild:
+    substitute:
+      SOPS_OPERATOR_VERSION: v0.9.0
+EOF
+```
+
+## Substitution Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `SOPS_OPERATOR_VERSION` | `v0.9.0` | Tag of the kustomize base — **keep the `v`** |
+| `FLUX_NAMESPACE` | `flux-system` | Where the source and Kustomization live |
+| `FLUX_SOURCE_API_VERSION` | `v1` | `source.toolkit.fluxcd.io` version |
+
+Do not pin below **v0.9.0**. Earlier tags carry an off-by-one: the repo writes
+`config/manager/kustomization.yaml` before tagging, so `ref=v0.8.5` built a
+bundle running image `v0.8.4`. Fixed in
+[sops-secrets-operator#90](https://github.com/stuttgart-things/sops-secrets-operator/pull/90).
+
+## Preconditions
+
+**cert-manager.** The operator ships a validating webhook, and the webhook
+cannot serve until cert-manager has issued its serving certificate. Without it
+the Deployment runs and every `SopsSecret` apply is rejected by a webhook that
+never answers — a failure that reads like a broken CRD.
+
+**An age key.** The operator does not carry one: it resolves the key per
+resource through `spec.decryption.keyRef`, so this app installs the operator and
+nothing else. How the key reaches the cluster is a separate decision and
+deliberately not baked in here — today the machinery play writes
+`sops-age-key` into `sops-secrets-operator-system` from `SOPS_AGE_KEY`, and a
+cluster with external-secrets could pull it from Vault instead.
+
+`v0.9.0` can additionally hold ONE global key for resources that omit `keyRef`
+([#47](https://github.com/stuttgart-things/sops-secrets-operator/pull/47)).
+That is opt-in and does not remove per-namespace copies: a resource's own
+`keyRef` always wins over the global default.
+
+## Namespace ownership
+
+The OCIRepository sits in `flux-system`, not in the operator's namespace. The
+base is a kubebuilder `config/default` and creates
+`sops-secrets-operator-system` itself; creating it here as well would give the
+namespace two owners across two Kustomizations, and a `prune` on either would
+take it out from under the other.
+
+For the same reason the Kustomization sets no `targetNamespace` — the base
+names its namespace throughout, and overriding it would rewrite the Deployment
+while leaving RBAC subjects and the webhook's service reference pointing at the
+old one.

--- a/apps/sops-secrets-operator/kustomization.yaml
+++ b/apps/sops-secrets-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - requirements.yaml
+  - release.yaml

--- a/apps/sops-secrets-operator/release.yaml
+++ b/apps/sops-secrets-operator/release.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sops-secrets-operator
+  namespace: ${FLUX_NAMESPACE:-flux-system}
+spec:
+  interval: 1h
+  retryInterval: 1m
+  # The base brings CRDs and a webhook, and the webhook cannot serve until
+  # cert-manager has issued its certificate. 5m is not enough on a cluster
+  # doing both for the first time.
+  timeout: 10m
+  sourceRef:
+    kind: OCIRepository
+    name: sops-secrets-operator-kustomize
+  prune: true
+  wait: true
+  # No targetNamespace: the base is a kubebuilder config/default and already
+  # names sops-secrets-operator-system throughout. Overriding it here would
+  # rewrite the namespace on the Deployment while leaving it in the RBAC
+  # subjects and the webhook's service reference.

--- a/apps/sops-secrets-operator/requirements.yaml
+++ b/apps/sops-secrets-operator/requirements.yaml
@@ -1,0 +1,22 @@
+---
+# The OCIRepository lives in flux-system, NOT in the operator's namespace.
+#
+# The kustomize base (config/default, kubebuilder layout) creates
+# sops-secrets-operator-system itself. Creating it here as well would give the
+# namespace two owners across two Kustomizations, and a later `prune` on either
+# would take it out from under the other. flux-system always exists, so the
+# source has somewhere to live without inventing an ordering problem.
+apiVersion: source.toolkit.fluxcd.io/${FLUX_SOURCE_API_VERSION:-v1}
+kind: OCIRepository
+metadata:
+  name: sops-secrets-operator-kustomize
+  namespace: ${FLUX_NAMESPACE:-flux-system}
+spec:
+  interval: 1h
+  url: oci://ghcr.io/stuttgart-things/sops-secrets-operator-kustomize
+  ref:
+    # The repo writes config/manager/kustomization.yaml before it tags, so a
+    # tagged tree pins its own image. Verified by building the bundle:
+    # ref=v0.8.5 gave image v0.8.4 — an off-by-one fixed by
+    # stuttgart-things/sops-secrets-operator#90. v0.9.0 gives v0.9.0.
+    tag: ${SOPS_OPERATOR_VERSION:-v0.9.0}


### PR DESCRIPTION
Installiert die OCI-Kustomize-Basis aus `config/default` des Operator-Repos — dieselbe Bundle, die der machinery-Play heute aus git anwendet. Ein Zielcluster bekommt sie damit auf demselben Weg wie alles andere, statt nur über einen Ansible-Lauf gegen den Seed.

## Zwei Platzierungsentscheidungen, die wie Versehen aussehen

**Die OCIRepository liegt in `flux-system`**, nicht im Namespace des Operators. Die Basis legt `sops-secrets-operator-system` selbst an — sie hier ebenfalls zu erzeugen gäbe dem Namespace zwei Eigentümer über zwei Kustomizations, und ein `prune` auf einer davon zöge ihn der anderen unter den Füßen weg.

**Die Kustomization setzt kein `targetNamespace`.** Die Basis benennt ihren Namespace durchgängig; ein Override schriebe das Deployment um und ließe die RBAC-Subjects und die Service-Referenz des Webhooks auf den alten zeigen.

## Der age-Key ist bewusst NICHT Teil der App

Der Operator trägt keinen Key — er löst ihn pro Ressource über `spec.decryption.keyRef` auf. Wie ein Key auf einen Cluster kommt, ist damit eine eigene Entscheidung: der Play schreibt ihn heute aus `SOPS_AGE_KEY`, ein Cluster mit external-secrets könnte ihn aus Vault ziehen.

## v0.9.0 ist ein Floor, keine Vorliebe

Das Repo schreibt `config/manager/kustomization.yaml` **vor** dem Taggen, also baute `ref=v0.8.5` ein Bundle mit Image `v0.8.4`. Behoben in [sops-secrets-operator#90](https://github.com/stuttgart-things/sops-secrets-operator/pull/90).

## Voraussetzung: cert-manager

Der Operator liefert einen Validating-Webhook, der ohne cert-manager-Zertifikat nicht antwortet. Ohne ihn läuft das Deployment, und jedes `SopsSecret`-Apply wird von einem Webhook abgelehnt, der nie antwortet — ein Fehler, der sich wie eine kaputte CRD liest.
