### PR TITLE
fix(tekton): default enable-api-fields to beta

### DIFF
--- a/cicd/tekton/README.md
+++ b/cicd/tekton/README.md
@@ -124,24 +124,41 @@ Results is therefore **disabled by default** (`TEKTON_RESULT_DISABLED`, default
 Dashboard. Set it to `false` on a cluster that has a default StorageClass and
 wants a run archive.
 
-## Caveat: `enable-api-fields` and Triggers
+## `enable-api-fields` defaults to `beta`, and why that reversed
 
-`TEKTON_ENABLE_API_FIELDS` defaults to `stable`, not `beta`.
+**`stable` breaks every AnsibleRun in this fleet.** Their pipelines are resolved
+through a git resolver, and resolver params are gated behind alpha/beta, so the
+admission webhook refuses the PipelineRun outright:
+
+```
+resolver params requires "enable-api-fields" feature gate to be "alpha" or "beta" but it is "stable"
+```
+
+Measured on `u26-rke2-1` (2026-08-17): the `AnsibleRun`'s Crossplane Object sat
+at `ReconcileError` and **no PipelineRun was ever created**, so the symptom is a
+VM stuck before provisioning, not something that looks like a Tekton problem.
+
+### The reason it used to default to `stable`
 
 The operator propagates this value from `TektonConfig` to every component, and
-**Triggers accepts only `stable` or `alpha`**. With `beta` the operator writes
-it onto `TektonTrigger`, gets it coerced back, and requeues forever:
+**Triggers accepts only `stable` or `alpha`**. An earlier attempt at `beta` left
+the operator requeueing forever:
 
 ```
 TektonConfig   Components not in ready state: TektonTrigger: reconcile again and proceed
 TektonTrigger  Ready=True   (all sub-conditions True, all three pods Running)
 ```
 
-The loop never converges and blocks every component after Triggers. Restarting
-the operator does not clear it — the value does.
+That did **not** reproduce on operator **v0.79.0**. After switching a live
+cluster to `beta`: `TektonConfig` reported `beta`, `TektonTrigger` kept
+`stable`, every component stayed `Ready`, and the operator logged zero requeue
+messages.
 
-A cluster that needs beta pipeline features can still set it, but then it needs
-`profile: basic` or an equivalent so Triggers is out of the picture.
+So the trade is no longer "beta risks a stuck operator" but "stable guarantees
+no AnsibleRun runs". If the loop returns on some operator version, set
+`TEKTON_ENABLE_API_FIELDS=alpha` — going back to `stable` takes the resolvers
+with it. A cluster that genuinely needs Triggers out of the picture can use
+`profile: basic`.
 
 ## Caveat: Pruner + Crossplane-managed PipelineRuns
 

--- a/cicd/tekton/components/config/tekton-config.yaml
+++ b/cicd/tekton/components/config/tekton-config.yaml
@@ -19,13 +19,27 @@ spec:
   result:
     disabled: ${TEKTON_RESULT_DISABLED:-true}
   pipeline:
-    # NOT propagated to Triggers by us — the operator does that itself, and
-    # Triggers accepts only `stable` or `alpha`. Setting `beta` here makes the
-    # operator try to write `beta` onto TektonTrigger, get it coerced back, and
-    # requeue forever with "Components not in ready state: TektonTrigger:
-    # reconcile again and proceed" while TektonTrigger itself reports Ready.
-    # Same cluster, same day. Keep this in step with what Triggers can take.
-    enable-api-fields: ${TEKTON_ENABLE_API_FIELDS:-stable}
+    # DEFAULT beta, not Tekton's own `stable`, because every AnsibleRun in this
+    # fleet resolves its pipeline through a git resolver — and resolver params
+    # are gated behind alpha/beta. With `stable` the PipelineRun is refused by
+    # the admission webhook:
+    #
+    #   resolver params requires "enable-api-fields" feature gate to be
+    #   "alpha" or "beta" but it is "stable"
+    #
+    # Measured on u26-rke2-1, 2026-08-17: the AnsibleRun's Object sat at
+    # ReconcileError and no PipelineRun was ever created, so the failure shows
+    # up as a VM stuck before provisioning rather than as a Tekton problem.
+    #
+    # There WAS a reason to fear beta here: the operator propagates this to
+    # TektonTrigger, which accepts only `stable` or `alpha`, and a previous
+    # attempt left it requeueing forever with "Components not in ready state:
+    # TektonTrigger". That did NOT reproduce on operator v0.79.0 — after the
+    # switch TektonConfig reported beta, TektonTrigger stayed `stable`, every
+    # component was Ready and the operator logged zero requeue messages. If it
+    # returns, set TEKTON_ENABLE_API_FIELDS=alpha rather than going back to
+    # stable, since stable takes the resolvers with it.
+    enable-api-fields: ${TEKTON_ENABLE_API_FIELDS:-beta}
     disable-inline-spec: ${TEKTON_DISABLE_INLINE_SPEC:-""}
   pruner:
     disabled: ${TEKTON_PRUNER_DISABLED:-false}


### PR DESCRIPTION
`stable` breaks every `AnsibleRun` in this fleet. Their pipelines are resolved through a **git resolver**, resolver params are gated behind alpha/beta, and the admission webhook refuses the PipelineRun outright:

```
resolver params requires "enable-api-fields" feature gate to be "alpha" or "beta" but it is "stable"
```

Measured on `u26-rke2-1` today: the AnsibleRun's Crossplane Object sat at `ReconcileError` and **no PipelineRun was ever created** — so the symptom is a VM stuck before provisioning, not something that reads as a Tekton problem.

**The default was `stable` for a real reason**, and I am not deleting that warning. The operator propagates this to `TektonTrigger`, which accepts only `stable` or `alpha`, and an earlier attempt left it requeueing forever with `Components not in ready state: TektonTrigger`.

That did **not** reproduce on operator **v0.79.0**. After switching a live cluster to `beta`: `TektonConfig` reported `beta`, `TektonTrigger` kept `stable`, every component stayed `Ready`, and the operator logged zero requeue messages.

So the trade is no longer "beta risks a stuck operator" but "stable guarantees no AnsibleRun runs". Both halves are in the README, with the escape hatch: if the loop returns on some operator version, use `alpha` — going back to `stable` takes the resolvers with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV5KDpXECT5DsiPQDnKrXL