### PR TITLE
fix(renovate): make HelmRelease chart versions visible to Renovate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,3 +138,42 @@ Run `pre-commit run --all-files` to validate before pushing. Active checks: trai
 ## Dependency Management
 
 Renovate is configured (`renovate.json`) with Flux-specific YAML file matching to automatically propose version updates for Helm charts and OCI artifacts.
+
+### Chart versions need a `# renovate:` annotation
+
+Renovate's `flux` manager reads `chart.spec.version`, but it cannot parse Flux
+variable substitution — `version: ${VAULT_VERSION:-1.9.0}` is skipped with
+`skipReason: contains-variable` and produces **no PR, no warning, no log entry**.
+
+Every HelmRelease whose chart version uses `${VAR:-default}` therefore carries a
+comment naming the datasource and where to look it up. A `customManager` in
+`renovate.json` matches the comment plus the following `version:` line and
+updates the default in place:
+
+```yaml
+  chart:
+    spec:
+      chart: cert-manager
+      # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
+      version: ${CERT_MANAGER_VERSION:-v1.19.2}
+```
+
+Derive the annotation from the `HelmRepository` the `sourceRef` points at:
+
+| HelmRepository | Annotation |
+|---|---|
+| `type: oci`, `url: oci://<host>/<path>` | `datasource=docker depName=<host>/<path>/<chart>` |
+| plain HTTPS repo | `datasource=helm depName=<chart> registryUrl=<url>` |
+
+**When adding a HelmRelease, add the annotation too** — without it the chart is
+silently invisible to Renovate and will never be updated.
+
+Verify locally against the real Renovate (`--dry-run` writes nothing):
+
+```bash
+docker run --rm -v "$PWD":/work -w /work \
+  -e RENOVATE_CONFIG_FILE=/work/renovate.json \
+  renovate/renovate:latest --platform=local --dry-run=extract
+```
+
+`skipReason: contains-variable` on a `chart.spec.version` means an annotation is missing.

--- a/apps/backstage/release.yaml
+++ b/apps/backstage/release.yaml
@@ -17,6 +17,7 @@ spec:
   chart:
     spec:
       chart: backstage
+      # renovate: datasource=docker depName=ghcr.io/backstage/charts/backstage
       version: ${BACKSTAGE_VERSION:-2.6.3}
       sourceRef:
         kind: HelmRepository

--- a/apps/cnpg-operator/release.yaml
+++ b/apps/cnpg-operator/release.yaml
@@ -10,6 +10,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
+      # renovate: datasource=helm depName=cloudnative-pg registryUrl=https://cloudnative-pg.github.io/charts
       version: ${CNPG_VERSION:-0.28.2}
       sourceRef:
         kind: HelmRepository

--- a/apps/dapr/components/control-plane/release.yaml
+++ b/apps/dapr/components/control-plane/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: dapr
+      # renovate: datasource=helm depName=dapr registryUrl=https://dapr.github.io/helm-charts
       version: ${DAPR_VERSION:-1.17.4}
       sourceRef:
         kind: HelmRepository

--- a/apps/dapr/components/redis-stack/release.yaml
+++ b/apps/dapr/components/redis-stack/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/charts/redis/redis
       version: ${DAPR_REDIS_VERSION:-17.1.4}
       sourceRef:
         kind: HelmRepository

--- a/apps/flux-web/release.yaml
+++ b/apps/flux-web/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: flux-operator
+      # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-operator
       version: ${FLUX_WEB_VERSION:-0.43.0}
       sourceRef:
         kind: HelmRepository

--- a/apps/harbor/components/project-proxy/release.yaml
+++ b/apps/harbor/components/project-proxy/release.yaml
@@ -13,6 +13,7 @@ spec:
   chart:
     spec:
       chart: harbor-project-proxy
+      # renovate: datasource=docker depName=ghcr.io/hiddenmarten/harbor-project-proxy
       version: ${HARBOR_PROJECT_PROXY_VERSION:-0.0.1}
       sourceRef:
         kind: HelmRepository

--- a/apps/harbor/release.yaml
+++ b/apps/harbor/release.yaml
@@ -13,6 +13,7 @@ spec:
   chart:
     spec:
       chart: harbor
+      # renovate: datasource=docker depName=registry-1.docker.io/bitnamicharts/harbor
       version: ${HARBOR_VERSION:-27.0.3}
       sourceRef:
         kind: HelmRepository

--- a/apps/headlamp/release.yaml
+++ b/apps/headlamp/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: headlamp
+      # renovate: datasource=helm depName=headlamp registryUrl=https://kubernetes-sigs.github.io/headlamp
       version: ${HEADLAMP_VERSION:-0.40.0}
       sourceRef:
         kind: HelmRepository

--- a/apps/homepage/release.yaml
+++ b/apps/homepage/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: homepage
+      # renovate: datasource=docker depName=ghcr.io/m0nsterrr/helm-charts/homepage
       version: ${HOMEPAGE_VERSION:-4.8.0}
       sourceRef:
         kind: HelmRepository

--- a/apps/homerun-base-stack/generic-pitcher.yaml
+++ b/apps/homerun-base-stack/generic-pitcher.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: homerun
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/homerun
       version: ${HOMERUN_VERSION:-v0.1.2}
       sourceRef:
         kind: HelmRepository

--- a/apps/homerun-base-stack/redis-stack.yaml
+++ b/apps/homerun-base-stack/redis-stack.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: homerun
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/homerun
       version: ${HOMERUN_VERSION:-v0.1.2}
       sourceRef:
         kind: HelmRepository

--- a/apps/homerun-base-stack/text-catcher.yaml
+++ b/apps/homerun-base-stack/text-catcher.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: homerun
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/homerun
       version: ${HOMERUN_VERSION:-v0.1.2}
       sourceRef:
         kind: HelmRepository

--- a/apps/homerun-iot-stack/light-catcher.yaml
+++ b/apps/homerun-iot-stack/light-catcher.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: homerun
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/homerun
       version: ${HOMERUN_VERSION:-v0.2.0}
       sourceRef:
         kind: HelmRepository

--- a/apps/kargo/release.yaml
+++ b/apps/kargo/release.yaml
@@ -13,6 +13,7 @@ spec:
   chart:
     spec:
       chart: kargo
+      # renovate: datasource=docker depName=ghcr.io/akuity/kargo-charts/kargo
       version: ${KARGO_VERSION:-1.9.6}
       sourceRef:
         kind: HelmRepository

--- a/apps/keycloak/release.yaml
+++ b/apps/keycloak/release.yaml
@@ -12,6 +12,7 @@ spec:
   chart:
     spec:
       chart: keycloak
+      # renovate: datasource=docker depName=registry-1.docker.io/bitnamicharts/keycloak
       version: ${KEYCLOAK_VERSION:-24.4.9}
       sourceRef:
         kind: HelmRepository

--- a/apps/minio/release.yaml
+++ b/apps/minio/release.yaml
@@ -13,6 +13,7 @@ spec:
   chart:
     spec:
       chart: charts/minio/minio
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/charts/minio/minio
       version: ${MINIO_VERSION:-16.0.10}
       sourceRef:
         kind: HelmRepository

--- a/apps/openldap/release.yaml
+++ b/apps/openldap/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: openldap-stack-ha
+      # renovate: datasource=helm depName=openldap-stack-ha registryUrl=https://jp-gouin.github.io/helm-openldap
       version: ${OPENLDAP_VERSION:-v4.3.2}
       sourceRef:
         kind: HelmRepository

--- a/apps/rancher/httproute.yaml
+++ b/apps/rancher/httproute.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: sthings-cluster
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/sthings-cluster
       version: ${STHINGS_CLUSTER_VERSION:-0.3.20}
       sourceRef:
         kind: HelmRepository

--- a/apps/rancher/pre-release.yaml
+++ b/apps/rancher/pre-release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: sthings-cluster
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/sthings-cluster
       version: ${STHINGS_CLUSTER_VERSION:-0.3.20}
       sourceRef:
         kind: HelmRepository

--- a/apps/rancher/release.yaml
+++ b/apps/rancher/release.yaml
@@ -12,6 +12,7 @@ spec:
   chart:
     spec:
       chart: rancher
+      # renovate: datasource=helm depName=rancher registryUrl=https://releases.rancher.com/server-charts/stable
       version: ${RANCHER_VERSION:-2.14.2}
       sourceRef:
         kind: HelmRepository

--- a/apps/redis-stack/release.yaml
+++ b/apps/redis-stack/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/charts/redis/redis
       version: ${REDIS_STACK_VERSION:-17.1.4}
       sourceRef:
         kind: HelmRepository

--- a/apps/uptime-kuma/release.yaml
+++ b/apps/uptime-kuma/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: uptime-kuma
+      # renovate: datasource=helm depName=uptime-kuma registryUrl=https://dirsigler.github.io/uptime-kuma-helm
       version: ${UPTIME_KUMA_VERSION:-4.0.0}
       sourceRef:
         kind: HelmRepository

--- a/apps/vault/autounseal/release.yaml
+++ b/apps/vault/autounseal/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: vault-autounseal
+      # renovate: datasource=helm depName=vault-autounseal registryUrl=https://pytoshka.github.io/vault-autounseal
       version: ${VAULT_AUTOUNSEAL_VERSION:-0.5.3}
       sourceRef:
         kind: HelmRepository

--- a/apps/vault/release.yaml
+++ b/apps/vault/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/vault/vault
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/charts/vault/vault
       version: ${VAULT_VERSION:-1.9.0}
       sourceRef:
         kind: HelmRepository

--- a/apps/vcluster/release.yaml
+++ b/apps/vcluster/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: vcluster
+      # renovate: datasource=helm depName=vcluster registryUrl=https://charts.loft.sh
       version: ${VCLUSTER_VERSION:-0.29.1}
       sourceRef:
         kind: HelmRepository

--- a/cicd/argo-cd/release.yaml
+++ b/cicd/argo-cd/release.yaml
@@ -13,6 +13,7 @@ spec:
   chart:
     spec:
       chart: argo-cd
+      # renovate: datasource=docker depName=ghcr.io/argoproj/argo-helm/argo-cd
       version: ${ARGO_CD_VERSION:-9.4.15}
       sourceRef:
         kind: HelmRepository

--- a/cicd/argo-rollouts/release.yaml
+++ b/cicd/argo-rollouts/release.yaml
@@ -10,6 +10,7 @@ spec:
   chart:
     spec:
       chart: argo-rollouts
+      # renovate: datasource=helm depName=argo-rollouts registryUrl=https://argoproj.github.io/argo-helm
       version: ${ARGO_ROLLOUTS_VERSION:-2.40.9}
       sourceRef:
         kind: HelmRepository

--- a/cicd/crossplane/components/install/release.yaml
+++ b/cicd/crossplane/components/install/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: crossplane
+      # renovate: datasource=helm depName=crossplane registryUrl=https://charts.crossplane.io/stable
       version: ${CROSSPLANE_VERSION:-2.2.0}
       sourceRef:
         kind: HelmRepository

--- a/cicd/komoplane/release.yaml
+++ b/cicd/komoplane/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: komoplane
+      # renovate: datasource=helm depName=komoplane registryUrl=https://helm-charts.komodor.io
       version: ${KOMOPLANE_VERSION:-0.1.6}
       sourceRef:
         kind: HelmRepository

--- a/cicd/kro/release.yaml
+++ b/cicd/kro/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: kro
+      # renovate: datasource=docker depName=registry.k8s.io/kro/charts/kro
       version: ${KRO_VERSION:-0.9.1}
       sourceRef:
         kind: HelmRepository

--- a/infra/cert-manager/components/install/release.yaml
+++ b/infra/cert-manager/components/install/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
+      # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
       version: ${CERT_MANAGER_VERSION:-v1.18.2}
       sourceRef:
         kind: HelmRepository

--- a/infra/cert-manager/release.yaml
+++ b/infra/cert-manager/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
+      # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
       version: ${CERT_MANAGER_VERSION:-v1.19.2}
       sourceRef:
         kind: HelmRepository

--- a/infra/cilium/components/install/release.yaml
+++ b/infra/cilium/components/install/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: cilium
+      # renovate: datasource=helm depName=cilium registryUrl=https://helm.cilium.io
       version: ${CILIUM_CHART_VERSION:-1.18.5}
       sourceRef:
         kind: HelmRepository

--- a/infra/external-secrets/components/install/release.yaml
+++ b/infra/external-secrets/components/install/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
+      # renovate: datasource=helm depName=external-secrets registryUrl=https://charts.external-secrets.io
       version: ${EXTERNAL_SECRETS_VERSION:-0.20.3}
       sourceRef:
         kind: HelmRepository

--- a/infra/ingress-nginx/release.yaml
+++ b/infra/ingress-nginx/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: ingress-nginx
+      # renovate: datasource=helm depName=ingress-nginx registryUrl=https://kubernetes.github.io/ingress-nginx
       version: ${INGRESS_NGINX_CHART_VERSION:-4.12.0}
       sourceRef:
         kind: HelmRepository

--- a/infra/kube-prometheus-stack/release.yaml
+++ b/infra/kube-prometheus-stack/release.yaml
@@ -10,6 +10,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
+      # renovate: datasource=helm depName=kube-prometheus-stack registryUrl=https://prometheus-community.github.io/helm-charts
       version: ${KPS_VERSION:-85.2.1}
       sourceRef:
         kind: HelmRepository

--- a/infra/metallb/release.yaml
+++ b/infra/metallb/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: metallb
+      # renovate: datasource=docker depName=registry-1.docker.io/bitnamicharts/metallb
       version: ${METALLB_CHART_VERSION:-6.4.2}
       sourceRef:
         kind: HelmRepository

--- a/infra/nfs-csi/release.yaml
+++ b/infra/nfs-csi/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: csi-driver-nfs
+      # renovate: datasource=helm depName=csi-driver-nfs registryUrl=https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
       version: ${NFS_CSI_VERSION:-v4.13.1}
       sourceRef:
         kind: HelmRepository

--- a/infra/openebs/release.yaml
+++ b/infra/openebs/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: openebs
+      # renovate: datasource=helm depName=openebs registryUrl=https://openebs.github.io/openebs
       version: ${OPENEBS_VERSION:-4.2.0}
       sourceRef:
         kind: HelmRepository

--- a/infra/prometheus/release.yaml
+++ b/infra/prometheus/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: prometheus
+      # renovate: datasource=helm depName=prometheus registryUrl=https://prometheus-community.github.io/helm-charts
       version: ${PROMETHEUS_VERSION:-28.13.0}
       sourceRef:
         kind: HelmRepository

--- a/infra/reloader/release.yaml
+++ b/infra/reloader/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: reloader
+      # renovate: datasource=helm depName=reloader registryUrl=https://stakater.github.io/stakater-charts
       version: ${RELOADER_VERSION:-2.2.12}
       sourceRef:
         kind: HelmRepository

--- a/infra/trust-manager/release.yaml
+++ b/infra/trust-manager/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: trust-manager
+      # renovate: datasource=helm depName=trust-manager registryUrl=https://charts.jetstack.io
       version: ${TRUST_MANAGER_VERSION:-0.22.0}
       sourceRef:
         kind: HelmRepository

--- a/infra/velero/release.yaml
+++ b/infra/velero/release.yaml
@@ -10,6 +10,7 @@ spec:
   chart:
     spec:
       chart: velero
+      # renovate: datasource=helm depName=velero registryUrl=https://vmware-tanzu.github.io/helm-charts
       version: ${VELERO_VERSION:-9.0.0}
       sourceRef:
         kind: HelmRepository

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,16 @@
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update HelmRelease chart.spec.version defaults behind Flux variable substitution. The flux manager skips these as contains-variable, so the datasource/registry is supplied by a preceding renovate comment.",
+      "fileMatch": [
+        "\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: registryUrl=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+version:\\s*\\$\\{[A-Z_]+:-(?<currentValue>[^}]+)\\}"
+      ]
     }
   ],
   "packageRules": [
@@ -50,7 +60,7 @@
       "groupName": "stuttgart-things images"
     },
     {
-      "description": "Auto-merge patch and digest updates once CI passes — keeps low-risk bumps from piling up",
+      "description": "Auto-merge patch and digest updates once CI passes \u2014 keeps low-risk bumps from piling up",
       "matchUpdateTypes": [
         "patch",
         "digest"


### PR DESCRIPTION
## Problem

Renovate has not opened a Helm chart PR for this repo in months. The app is fine and so is the config — the `flux` manager simply cannot see the charts.

It reads `chart.spec.version`, but it cannot parse Flux variable substitution. `version: ${VAULT_VERSION:-1.9.0}` is dropped with `skipReason: contains-variable` — silently, with no warning and no log line.

**All 43 HelmReleases** in `apps/`, `infra/` and `cicd/` pin their chart version that way, so none of them has ever produced an update PR. The two existing custom managers cover only `OCIRepository.ref.tag` and `image: repo:${VAR:-...}`; `chart.spec.version` was covered by nothing.

What kept arriving were `github-actions` and `dockerfile` PRs, which run on their own default matching. That made the gap look like "Renovate is broken" rather than a manager blind spot.

Note `fileMatch` was **not** the cause: Renovate 44 migrates it cleanly to `managerFilePatterns: ["/\\.yaml$/"]`. The revert in #186 had no effect either way.

## Fix

A third `customManager` that reads a `# renovate:` annotation preceding the version line — the same convention [stuttgart-things/argocd](https://github.com/stuttgart-things/argocd/blob/main/renovate.json) already uses — plus the annotation on all 43 releases.

```yaml
  chart:
    spec:
      chart: cert-manager
      # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
      version: ${CERT_MANAGER_VERSION:-v1.19.2}
```

Datasource and registry are derived from the `HelmRepository` each `sourceRef` points at:

| HelmRepository | Annotation |
|---|---|
| `type: oci`, `url: oci://<host>/<path>` | `datasource=docker depName=<host>/<path>/<chart>` |
| plain HTTPS repo | `datasource=helm depName=<chart> registryUrl=<url>` |

The manager deliberately sets no `versioningTemplate`/`extractVersionTemplate`. The existing managers' `extractVersion: ^v?(?<version>.*)$` would strip the `v` from v-prefixed chart versions (cert-manager `v1.19.2`, csi-driver-nfs `v4.13.1`) and write a broken default on bump.

## Verification

Renovate 44 run against this tree, both states, `--dry-run=full` (writes nothing):

```bash
docker run --rm -v "$PWD":/work -w /work \
  -e RENOVATE_CONFIG_FILE=/work/renovate.json \
  renovate/renovate:latest --platform=local --dry-run=full
```

| | prospective update branches |
|---|---|
| `main` (unchanged) | **2** |
| this branch | **39** |

Zero lookup failures across all 43 annotations — every one resolves against its real registry. Among them cilium, cert-manager, kube-prometheus-stack, velero, argo-cd, crossplane and vcluster.

The 39 arrive throttled by the existing `prConcurrentLimit: 10`, the default `prHourlyLimit: 2` and `minimumReleaseAge: 3 days`. Seven are majors (velero 9→12, prometheus 28→29, keycloak 24→25, argo-cd 9→10, external-secrets 0→2, homepage 4→5, kube-prometheus-stack 85→88); the existing packageRule labels them `major-update` and keeps automerge off.

## Also

`CLAUDE.md` gains a section on the annotation, the derivation rule and the local verification command — without it the next new component silently drops out of Renovate's view again.

## Notes for review

- No manifest semantics change: every edit is one added comment line. The `version:` values themselves are untouched.
- `pre-commit --all-files` reports secret findings, but all of them pre-exist on `main` (`existingSecret:` tripping the keyword heuristic). A stash run reproduces them identically.
- `apps/vault/autounseal` has a HelmRepository URL that is itself substituted; its default (`https://pytoshka.github.io/vault-autounseal`) is used as the `registryUrl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi