### PR TITLE
feat(taskfile): add renovate check/lint/preview tasks, fix numeric substitution vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ This project uses [go-task](https://taskfile.dev) instead of Make. The Taskfile 
 task get-variables   # Extract all ${VAR:-default} substitution variables from an app folder
 task release         # Run semantic-release (dry-run then actual) and push a new version tag
 task do              # Interactive task picker (requires gum)
+
+task check-renovate    # Fail if a substituted chart version lacks its "# renovate:" annotation
+task lint-renovate     # Validate renovate.json against the current Renovate schema
+task preview-renovate  # Dry-run Renovate locally and list the updates it would propose
 task pr              # Create a pull request (via included git tasks)
 ```
 
@@ -168,12 +172,10 @@ Derive the annotation from the `HelmRepository` the `sourceRef` points at:
 **When adding a HelmRelease, add the annotation too** — without it the chart is
 silently invisible to Renovate and will never be updated.
 
-Verify locally against the real Renovate (`--dry-run` writes nothing):
+`task check-renovate` fails on any chart version that is missing its annotation, and
+`task preview-renovate` runs the real Renovate against the working tree (writing
+nothing) to list the updates it would propose plus any lookup failures.
 
-```bash
-docker run --rm -v "$PWD":/work -w /work \
-  -e RENOVATE_CONFIG_FILE=/work/renovate.json \
-  renovate/renovate:latest --platform=local --dry-run=extract
-```
-
-`skipReason: contains-variable` on a `chart.spec.version` means an annotation is missing.
+Note the substitution variable may contain digits (`${HOMERUN2_REDIS_VERSION:-17.1.4}`),
+so every `matchStrings` regex in `renovate.json` uses `[A-Z0-9_]+` — a narrower
+`[A-Z_]+` silently skips those components.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -11,6 +11,10 @@ vars:
   DAGGER_DOCKER_MODULE: github.com/stuttgart-things/dagger/docker
   DAGGER_DOCKER_MODULE_VERSION: main
 
+  # Renovate image used by the lint-/check-/preview-renovate tasks.
+  # Tracks "latest" on purpose — that is what Mend Cloud runs against this repo.
+  RENOVATE_IMAGE: renovate/renovate:latest
+
   # sthings-sops-cmp image (Argo CD CMP sidecar for SOPS).
   # Tag scheme: sops-age-kustomize-helm — keep in sync with ARG defaults in
   # cicd/argo-cd/sops-cmp/Dockerfile.
@@ -122,3 +126,88 @@ tasks:
           --registry-username env:GITHUB_USER \
           --registry-password env:GITHUB_TOKEN \
           --progress plain
+
+  lint-renovate:
+    desc: Validate renovate.json against the current Renovate config schema
+    cmds:
+      - |
+        docker run --rm \
+          -v "${PWD}/renovate.json":/tmp/renovate.json:ro \
+          {{.RENOVATE_IMAGE}} \
+          renovate-config-validator /tmp/renovate.json
+
+  check-renovate:
+    desc: Fail if a substituted HelmRelease chart version lacks its "# renovate:" annotation
+    silent: true
+    cmds:
+      - |
+        # Renovate's flux manager cannot parse ${VAR:-1.2.3} in chart.spec.version;
+        # it drops the dep as "contains-variable" without warning. The annotation on
+        # the preceding line is what feeds the custom manager instead — so a missing
+        # one means that chart silently never gets an update PR.
+        missing=$(find apps infra cicd -name '*.yaml' -print0 \
+          | xargs -0 awk '
+              FNR == 1 { prev = "" }
+              /^[[:space:]]*version:[[:space:]]*\$\{[A-Z0-9_]+:-/ {
+                if (prev !~ /#[[:space:]]*renovate:/) printf "  %s:%d\n", FILENAME, FNR
+              }
+              { prev = $0 }
+            ')
+
+        if [ -n "${missing}" ]; then
+          echo "Chart versions with no '# renovate:' annotation:"
+          echo "${missing}"
+          echo
+          echo "Renovate will never propose an update for these."
+          echo "Derive the annotation from the HelmRepository the sourceRef points at:"
+          echo "  type: oci   -> # renovate: datasource=docker depName=<host>/<path>/<chart>"
+          echo "  plain HTTPS -> # renovate: datasource=helm depName=<chart> registryUrl=<url>"
+          echo "See CLAUDE.md -> Dependency Management."
+          exit 1
+        fi
+
+        echo "OK: every substituted chart version is annotated."
+
+  preview-renovate:
+    desc: Dry-run Renovate over a copy of the working tree and list the updates it would propose
+    silent: true
+    vars:
+      PREVIEW_DIR: /tmp/renovate-preview
+    preconditions:
+      - sh: command -v docker
+        msg: "docker is required to run Renovate locally"
+    cmds:
+      - |
+        # Run against a copy: --dry-run writes no commits, but the container would
+        # still churn caches inside a mounted working tree.
+        rm -rf {{.PREVIEW_DIR}} && mkdir -p {{.PREVIEW_DIR}}
+        tar --exclude=.git --exclude=.task -cf - . | tar -xf - -C {{.PREVIEW_DIR}}
+        chmod -R a+rwX {{.PREVIEW_DIR}}
+
+        # A token only widens lookups to GitHub-hosted datasources; helm/docker work without.
+        token="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+
+        echo "Running {{.RENOVATE_IMAGE}} against the working tree (this takes a minute)..."
+        docker run --rm -u 0 \
+          -v {{.PREVIEW_DIR}}:/work -w /work \
+          -e RENOVATE_CONFIG_FILE=/work/renovate.json \
+          -e LOG_LEVEL=debug \
+          -e GITHUB_COM_TOKEN="${token}" \
+          {{.RENOVATE_IMAGE}} \
+          --platform=local --dry-run=full > {{.PREVIEW_DIR}}/renovate.log 2>&1 || true
+
+        echo
+        echo "Updates Renovate would propose:"
+        grep -oE '"branchName": "renovate/[^"]*"' {{.PREVIEW_DIR}}/renovate.log \
+          | sed 's|.*renovate/|  |; s|"$||' | sort -u
+        echo
+        echo "  total: $(grep -oE '"branchName": "renovate/[^"]*"' {{.PREVIEW_DIR}}/renovate.log | sort -u | wc -l)"
+
+        if grep -qiE 'failed to look up' {{.PREVIEW_DIR}}/renovate.log; then
+          echo
+          echo "Lookup failures (wrong depName or registryUrl in an annotation):"
+          grep -iE 'failed to look up' {{.PREVIEW_DIR}}/renovate.log | sed 's/^/  /' | sort -u
+        fi
+
+        echo
+        echo "Full log: {{.PREVIEW_DIR}}/renovate.log"

--- a/apps/homerun2/components/redis-stack/release.yaml
+++ b/apps/homerun2/components/redis-stack/release.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: redis
+      # renovate: datasource=docker depName=ghcr.io/stuttgart-things/charts/redis/redis
       version: ${HOMERUN2_REDIS_VERSION:-17.1.4}
       sourceRef:
         kind: HelmRepository

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
         "\\.yaml$"
       ],
       "matchStrings": [
-        "url:\\s*oci://(?<depName>[^\\s]+)\\s*\\n\\s*ref:\\s*\\n\\s*tag:\\s*\\$\\{[A-Z_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
+        "url:\\s*oci://(?<depName>[^\\s]+)\\s*\\n\\s*ref:\\s*\\n\\s*tag:\\s*\\$\\{[A-Z0-9_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver",
@@ -31,7 +31,7 @@
         "\\.yaml$"
       ],
       "matchStrings": [
-        "image:\\s*(?<depName>[^:$\\s]+):\\$\\{[A-Z_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
+        "image:\\s*(?<depName>[^:$\\s]+):\\$\\{[A-Z0-9_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver",
@@ -44,7 +44,7 @@
         "\\.yaml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: registryUrl=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+version:\\s*\\$\\{[A-Z_]+:-(?<currentValue>[^}]+)\\}"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: registryUrl=(?<registryUrl>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+version:\\s*\\$\\{[A-Z0-9_]+:-(?<currentValue>[^}]+)\\}"
       ]
     }
   ],


### PR DESCRIPTION
Follow-up to #203. Adds the tasks to check the Renovate wiring locally — and the first run of one of them found a bug that predates #203.

## Tasks

| Task | What it does | Needs docker |
|---|---|---|
| `check-renovate` | Fails on any substituted chart version missing its `# renovate:` annotation | no |
| `lint-renovate` | Validates `renovate.json` against the current schema | yes |
| `preview-renovate` | Runs the real Renovate over a copy of the working tree (`--dry-run`, writes nothing) and lists the updates it would propose plus any lookup failures | yes |

`preview-renovate` copies the tree to `/tmp` first — `--dry-run` writes no commits, but the container would otherwise churn caches inside the working tree.

## The bug it found

The manager regexes matched the substitution variable as `[A-Z_]+`, which does not cover a digit. So `${HOMERUN2_REDIS_VERSION:-17.1.4}` never matched.

This is **not** limited to the chart-version manager added in #203 — it applies equally to the OCIRepository `ref.tag` and `image:` managers that predate it. Every `HOMERUN2_*` component has therefore been invisible to Renovate the whole time and has never received an update PR.

Widening all three regexes to `[A-Z0-9_]+` brings **18 homerun2 components** into view — 9 apps, each an image plus its `-kustomize` OCI artifact:

```
ghcr.io/stuttgart-things/homerun2-core-catcher            v0.5.0
ghcr.io/stuttgart-things/homerun2-core-catcher-kustomize  v0.5.0
ghcr.io/stuttgart-things/homerun2-demo-pitcher            v1.4.0
...
```

The same blind spot cost `apps/homerun2/components/redis-stack/release.yaml` its annotation in #203 — `check-renovate` flagged it on the very first run, and it is added here.

## Verification

`task preview-renovate` against this branch:

- regex manager: **55 → 150** extracted deps
- all homerun2 deps resolve with clean `currentValue`s (`v0.5.0`, not `${VAR:-v0.5.0}`)
- `task check-renovate` passes; `task lint-renovate` validates
- proposed updates stay at **39** — every homerun2 version is currently up to date. The point is not new PRs today, it is that their future bumps are seen at all.

The only remaining lookup failure is pre-existing and unrelated: `ghcr.io/stuttgart-things/clusterscope-kustomize-multi-repo` does not exist under that name (`apps/clusterscope/release.yaml`). Left alone here; it also shows under *Repository Problems* on the dependency dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi