### PR TITLE
fix(renovate): stop stripping the v from tags that need it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ task do              # Interactive task picker (requires gum)
 task check-renovate    # Fail if a substituted chart version lacks its "# renovate:" annotation
 task lint-renovate     # Validate renovate.json against the current Renovate schema
 task preview-renovate  # Dry-run Renovate locally and list the updates it would propose
+task verify-image-tags # Check every substituted image tag actually exists in its registry
 task pr              # Create a pull request (via included git tasks)
 ```
 
@@ -179,3 +180,18 @@ nothing) to list the updates it would propose plus any lookup failures.
 Note the substitution variable may contain digits (`${HOMERUN2_REDIS_VERSION:-17.1.4}`),
 so every `matchStrings` regex in `renovate.json` uses `[A-Z0-9_]+` — a narrower
 `[A-Z_]+` silently skips those components.
+
+### Never set `extractVersionTemplate` on these managers
+
+`extractVersion` does not only normalise the version for comparison — Renovate
+writes the **extracted** value back. With `^v?(?<version>.*)$` a registry tag of
+`v0.8.2` is written as `0.8.2`, and since most `ghcr.io/stuttgart-things/*`
+artifacts are tagged **with** the `v`, the result is a default that resolves to
+no tag at all. That failure only surfaces at deploy time.
+
+Leave the field off and each datasource's own versioning applies, so the tag is
+written back exactly as the registry publishes it — `v0.5.0` stays `v0.5.0`,
+`1.25.9` stays `1.25.9`.
+
+`task verify-image-tags` resolves every substituted default against the real
+registry and is the check that catches this class of breakage.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -168,6 +168,12 @@ tasks:
 
         echo "OK: every substituted chart version is annotated."
 
+  verify-image-tags:
+    desc: Check that every substituted image tag / OCIRepository ref exists in its registry
+    silent: true
+    cmds:
+      - python3 hack/verify-image-tags.py {{.CLI_ARGS}}
+
   preview-renovate:
     desc: Dry-run Renovate over a copy of the working tree and list the updates it would propose
     silent: true

--- a/apps/clusterbook-operator/release.yaml
+++ b/apps/clusterbook-operator/release.yaml
@@ -29,7 +29,7 @@ spec:
             spec:
               containers:
                 - name: manager
-                  image: ghcr.io/stuttgart-things/clusterbook-operator:${CLUSTERBOOK_OPERATOR_VERSION:-0.19.0}
+                  image: ghcr.io/stuttgart-things/clusterbook-operator:${CLUSTERBOOK_OPERATOR_VERSION:-v0.19.0}
     # Mount trust-manager CA bundle so the operator can verify the
     # internal clusterbook server (clusterbook.infra.sthings-vsphere…)
     # when ProviderConfig.spec.insecureSkipVerify is false.

--- a/apps/clusterbook-operator/requirements.yaml
+++ b/apps/clusterbook-operator/requirements.yaml
@@ -15,4 +15,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/clusterbook-operator-kustomize
   ref:
-    tag: ${CLUSTERBOOK_OPERATOR_VERSION:-0.19.0}
+    tag: ${CLUSTERBOOK_OPERATOR_VERSION:-v0.19.0}

--- a/apps/clusterbook/release.yaml
+++ b/apps/clusterbook/release.yaml
@@ -29,7 +29,7 @@ spec:
             spec:
               containers:
                 - name: clusterbook
-                  image: ghcr.io/stuttgart-things/clusterbook:${CLUSTERBOOK_VERSION:-1.25.9}
+                  image: ghcr.io/stuttgart-things/clusterbook:${CLUSTERBOOK_VERSION:-v1.25.9}
     # Override PowerDNS + DD-WRT config in ConfigMap
     - target:
         kind: ConfigMap

--- a/apps/clusterbook/requirements.yaml
+++ b/apps/clusterbook/requirements.yaml
@@ -15,4 +15,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/clusterbook-kustomize
   ref:
-    tag: ${CLUSTERBOOK_VERSION:-1.25.9}
+    tag: ${CLUSTERBOOK_VERSION:-v1.25.9}

--- a/apps/run-things/release.yaml
+++ b/apps/run-things/release.yaml
@@ -29,7 +29,7 @@ spec:
             spec:
               containers:
                 - name: run-things
-                  image: ghcr.io/stuttgart-things/run-things:${RUN_THINGS_VERSION:-1.0.0}
+                  image: ghcr.io/stuttgart-things/run-things:${RUN_THINGS_VERSION:-v1.0.0}
     # Override config in ConfigMap
     - target:
         kind: ConfigMap

--- a/apps/run-things/requirements.yaml
+++ b/apps/run-things/requirements.yaml
@@ -15,4 +15,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/run-things-kustomize
   ref:
-    tag: ${RUN_THINGS_VERSION:-1.0.0}
+    tag: ${RUN_THINGS_VERSION:-v1.0.0}

--- a/hack/verify-image-tags.py
+++ b/hack/verify-image-tags.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Check that every substituted image tag / OCIRepository ref actually exists.
+
+Renovate writes these defaults, and a manager misconfigured with
+extractVersionTemplate will happily strip a "v" that the registry requires --
+producing a tag that resolves to nothing until a deploy fails. This walks the
+manifests, resolves each default against the real registry and reports misses.
+
+Only ghcr.io and docker.io are queried; anything else is reported as skipped
+rather than silently counted as fine.
+"""
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+TIMEOUT = 20
+UNREADABLE = "unreadable"
+_tag_cache: dict[str, set[str] | str | None] = {}
+
+
+def _get(url: str, token: str | None = None) -> tuple[dict, str | None]:
+    """Fetch JSON and return it with the Link rel=next URL, if any."""
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        body = json.load(r)
+        link = r.headers.get("link", "")
+    nxt = None
+    m = re.search(r'<([^>]+)>\s*;\s*rel="?next"?', link)
+    if m:
+        nxt = m.group(1)
+    return body, nxt
+
+
+def _all_tags(listing: str, host: str, token: str | None) -> set[str]:
+    """Registries page tag lists -- ghcr.io caps at 100 without ?n=, and a repo
+    with many tags still spans pages. Miss this and existing tags look absent."""
+    tags: set[str] = set()
+    url = f"{listing}?n=1000"
+    for _ in range(50):  # generous page cap, guards against a cyclic Link header
+        body, nxt = _get(url, token)
+        tags.update(body.get("tags") or [])
+        if not nxt:
+            break
+        url = nxt if nxt.startswith("http") else f"https://{host}{nxt}"
+    return tags
+
+
+def tags_for(image: str) -> set[str] | str | None:
+    """Return the tag set for host/path, or None if the registry is unsupported."""
+    if image in _tag_cache:
+        return _tag_cache[image]
+
+    host, _, path = image.partition("/")
+    if host == "ghcr.io":
+        auth = f"https://ghcr.io/token?scope=repository:{path}:pull&service=ghcr.io"
+        listing = f"https://ghcr.io/v2/{path}/tags/list"
+    elif host in ("docker.io", "registry-1.docker.io", "index.docker.io"):
+        if "/" not in path:
+            path = f"library/{path}"
+        auth = f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{path}:pull"
+        listing = f"https://registry-1.docker.io/v2/{path}/tags/list"
+    else:
+        _tag_cache[image] = None
+        return None
+
+    try:
+        token = _get(auth)[0].get("token")
+        tags = _all_tags(listing, host if host != "docker.io" else "registry-1.docker.io", token)
+    except (urllib.error.URLError, urllib.error.HTTPError, ValueError, KeyError):
+        # 403/404/network: the repo may be private or renamed. Either way we
+        # cannot judge its tags -- report it as unverifiable, never as missing.
+        tags = UNREADABLE
+    _tag_cache[image] = tags
+    return tags
+
+
+# image: <repo>:${VAR:-<tag>}
+IMAGE_RE = re.compile(r"image:\s*(?P<image>[^:$\s]+):\$\{[A-Z0-9_]+:-(?P<tag>[^}]+)\}")
+# OCIRepository: url: oci://<repo> ... ref: tag: ${VAR:-<tag>}
+OCI_RE = re.compile(
+    r"url:\s*oci://(?P<image>\S+)\s*\n\s*ref:\s*\n\s*tag:\s*\$\{[A-Z0-9_]+:-(?P<tag>[^}]+)\}"
+)
+
+
+def main(roots: list[str]) -> int:
+    missing, skipped, unreadable, checked = [], [], [], 0
+
+    for root in roots:
+        for f in sorted(Path(root).rglob("*.yaml")):
+            text = f.read_text()
+            for rx in (IMAGE_RE, OCI_RE):
+                for m in rx.finditer(text):
+                    image, tag = m.group("image"), m.group("tag")
+                    if "/" not in image:               # bare docker hub name
+                        image = f"docker.io/library/{image}"
+                    elif image.count("/") == 1 and "." not in image.split("/")[0]:
+                        image = f"docker.io/{image}"
+                    line = text[: m.start()].count("\n") + 1
+
+                    tags = tags_for(image)
+                    if tags is None:
+                        skipped.append(f"  {f}:{line}  {image}:{tag}  (registry not queried)")
+                        continue
+                    if tags is UNREADABLE:
+                        unreadable.append(f"  {f}:{line}  {image}:{tag}  (private, renamed or gone)")
+                        continue
+                    checked += 1
+                    if tag not in tags:
+                        near = sorted(t for t in tags if t.lstrip("v").startswith(tag.lstrip("v")[:3]))
+                        hint = f"  did you mean: {', '.join(near[-3:])}" if near else ""
+                        missing.append(f"  {f}:{line}  {image}:{tag} does not exist{hint}")
+
+    if skipped:
+        print("Skipped (only ghcr.io and docker.io are queried):")
+        print("\n".join(sorted(set(skipped))))
+        print()
+
+    if unreadable:
+        print("Could not read these repositories -- tags unverified:")
+        print("\n".join(sorted(set(unreadable))))
+        print()
+
+    if missing:
+        print(f"Tags that do not exist ({len(missing)} of {checked} checked):")
+        print("\n".join(missing))
+        print()
+        print("A default that resolves to nothing fails at deploy time, not here.")
+        return 1
+
+    print(f"OK: all {checked} substituted image tags exist in their registry.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:] or ["apps", "infra", "cicd"]))

--- a/infra/velero/release.yaml
+++ b/infra/velero/release.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     initContainers:
       - name: velero-plugin-for-aws
-        image: velero/velero-plugin-for-aws:${VELERO_PLUGIN_AWS_VERSION:-1.14.2}
+        image: velero/velero-plugin-for-aws:${VELERO_PLUGIN_AWS_VERSION:-v1.14.2}
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: plugins

--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,7 @@
         "url:\\s*oci://(?<depName>[^\\s]+)\\s*\\n\\s*ref:\\s*\\n\\s*tag:\\s*\\$\\{[A-Z0-9_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
       ],
       "datasourceTemplate": "docker",
-      "versioningTemplate": "semver",
-      "extractVersionTemplate": "^v?(?<version>.*)$"
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",
@@ -34,8 +33,7 @@
         "image:\\s*(?<depName>[^:$\\s]+):\\$\\{[A-Z0-9_]+:-(?<currentValue>v?\\d+\\.\\d+\\.\\d+[^}]*)\\}"
       ],
       "datasourceTemplate": "docker",
-      "versioningTemplate": "semver",
-      "extractVersionTemplate": "^v?(?<version>.*)$"
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Follow-up to #203/#206. **Renovate has been writing tags that do not exist**, and #206 widened the blast radius.

## Cause

`extractVersion` does not only normalise a version for comparison — Renovate writes the *extracted* value back into the file. Both older custom managers carry:

```json
"extractVersionTemplate": "^v?(?<version>.*)$"
```

So a registry tag of `v0.8.2` gets written as `0.8.2`. Most `ghcr.io/stuttgart-things/*` artifacts are tagged **with** the `v`, which makes the resulting default resolve to no tag at all — and that only surfaces when a cluster tries to pull it.

## This already happened

Renovate wrote these itself. Verified against the live registries:

| File | Current default | Registry has |
|---|---|---|
| `infra/velero` | `velero-plugin-for-aws:1.14.2` | only `v1.14.2` (#175) |
| `apps/clusterbook` | `clusterbook:1.25.9` | only `v1.25.9` (#130) |
| `apps/clusterbook-operator` | `...:0.19.0` | only `v0.19.0` (#134) |
| `apps/run-things` | `run-things:1.0.0` | only `v1.0.0` (#75) |

PR #194 ("v-prefixed version default") was this same damage being repaired by hand without the cause being found.

It got more urgent with #206: that brought 18 homerun2 components into view, all of them v-tagged, and **patch updates automerge**. From the dry-run log:

```
homerun2-scout  currentValue: v0.5.0  ->  newValue: 0.8.2      # v0.5.0 exists, 0.5.0 does not
```

## Fix

Drop `extractVersionTemplate` from both managers. Each datasource's own versioning then applies and the tag is written back exactly as published. Verified across all 26 affected deps:

```
homerun2-scout    v0.5.0  -> v0.8.2     prefix kept
clusterbook       1.25.9  -> 1.25.11    stays unprefixed
```

The six broken defaults are corrected in this PR.

## New check

`hack/verify-image-tags.py` + `task verify-image-tags` resolves every substituted default against the real registry — the check that would have caught this years' worth of drift.

Two things it gets right that a naive version would not:

- **Pagination.** ghcr.io caps tag lists at 100 without `?n=`, and `machinery` alone has 289 tags. Ignoring the `Link` header reported 4 existing tags as missing in an earlier draft.
- **Unreadable ≠ absent.** A 403 (private/renamed repo) is reported separately, never as a broken tag.

## Still open, deliberately not touched

`task verify-image-tags` still reports four findings that are a *different* problem — deleted or never-published tags, not the prefix bug — so I did not guess at replacements:

```
homerun2-demo-pitcher-kustomize:v1.4.0   gone (registry starts at v1.6.1)
homerun2-wled-mock:v0.3.0                gone
homerun2-wled-mock-kustomize:v0.3.0      gone
homerun2-led-catcher-kustomize:latest    never published
clusterscope-kustomize-multi-repo        403 — unverified
```

These need someone who knows which version those components should actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi