### PR TITLE
fix(homerun2,clusterscope): point image tags at artifacts that exist

### DIFF
--- a/apps/clusterscope/release.yaml
+++ b/apps/clusterscope/release.yaml
@@ -132,7 +132,10 @@ spec:
   url: oci://ghcr.io/stuttgart-things/clusterscope-kustomize-multi-repo
   ref:
     tag: ${CLUSTERSCOPE_VERSION:-v0.20.2}
-  # suspend: true  # remove to activate
+  # Suspended: oci://ghcr.io/stuttgart-things/clusterscope-kustomize-multi-repo
+  # returns 403 -- the package is private, renamed or was never published, so
+  # every reconcile fails. Remove both suspends once it resolves. See #208.
+  suspend: true
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -150,7 +153,8 @@ spec:
   prune: true
   wait: true
   targetNamespace: ${CLUSTERSCOPE_NAMESPACE:-clusterscope}
-  # suspend: true  # remove to activate
+  # Suspended alongside its OCIRepository above. See #208.
+  suspend: true
   patches:
     # Remove the KCL-generated HTTPRoute (managed via httproute.yaml)
     - target:

--- a/apps/homerun2/components/demo-pitcher/release.yaml
+++ b/apps/homerun2/components/demo-pitcher/release.yaml
@@ -49,7 +49,7 @@ spec:
             spec:
               containers:
                 - name: homerun2-demo-pitcher
-                  image: ghcr.io/stuttgart-things/homerun2-demo-pitcher:${HOMERUN2_DEMO_PITCHER_VERSION:-v1.4.0}
+                  image: ghcr.io/stuttgart-things/homerun2-demo-pitcher:${HOMERUN2_DEMO_PITCHER_VERSION:-v1.8.2}
     # Override the Redis password secret
     - target:
         kind: Secret

--- a/apps/homerun2/components/demo-pitcher/requirements.yaml
+++ b/apps/homerun2/components/demo-pitcher/requirements.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/homerun2-demo-pitcher-kustomize
   ref:
-    tag: ${HOMERUN2_DEMO_PITCHER_VERSION:-v1.4.0}
+    tag: ${HOMERUN2_DEMO_PITCHER_VERSION:-v1.8.2}

--- a/apps/homerun2/components/led-catcher/release.yaml
+++ b/apps/homerun2/components/led-catcher/release.yaml
@@ -39,7 +39,7 @@ spec:
             spec:
               containers:
                 - name: homerun2-led-catcher
-                  image: ghcr.io/stuttgart-things/homerun2-led-catcher:${HOMERUN2_LED_CATCHER_VERSION:-latest}
+                  image: ghcr.io/stuttgart-things/homerun2-led-catcher:${HOMERUN2_LED_CATCHER_VERSION:-v0.2.2}
     # Override the Redis password secret
     - target:
         kind: Secret

--- a/apps/homerun2/components/led-catcher/requirements.yaml
+++ b/apps/homerun2/components/led-catcher/requirements.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/homerun2-led-catcher-kustomize
   ref:
-    tag: ${HOMERUN2_LED_CATCHER_VERSION:-latest}
+    tag: ${HOMERUN2_LED_CATCHER_VERSION:-v0.2.2}

--- a/apps/homerun2/components/wled-mock/release.yaml
+++ b/apps/homerun2/components/wled-mock/release.yaml
@@ -29,4 +29,4 @@ spec:
             spec:
               containers:
                 - name: homerun2-wled-mock
-                  image: ghcr.io/stuttgart-things/homerun2-wled-mock:${HOMERUN2_WLED_MOCK_VERSION:-v0.3.0}
+                  image: ghcr.io/stuttgart-things/homerun2-wled-mock:${HOMERUN2_WLED_MOCK_VERSION:-v0.7.4}

--- a/apps/homerun2/components/wled-mock/requirements.yaml
+++ b/apps/homerun2/components/wled-mock/requirements.yaml
@@ -8,4 +8,4 @@ spec:
   interval: 1h
   url: oci://ghcr.io/stuttgart-things/homerun2-wled-mock-kustomize
   ref:
-    tag: ${HOMERUN2_WLED_MOCK_VERSION:-v0.3.0}
+    tag: ${HOMERUN2_WLED_MOCK_VERSION:-v0.7.4}


### PR DESCRIPTION
Closes #208.

`task verify-image-tags` reported five references resolving to nothing. Unlike the v-prefix damage in #207, these were **not** written by Renovate — they are tags that were deleted, never published, or belong to a repository that no longer answers. Each fails the Flux reconcile at pull time for anyone not overriding the variable.

## Version choices

One variable drives both the container image and its `-kustomize` OCI artifact, and the two have drifted apart. Each default is the newest version available for **both** artifacts, within the current major line:

| Component | Was | Now | Why it was broken |
|---|---|---|---|
| `demo-pitcher` | `v1.4.0` | **`v1.8.2`** | image had `v1.4.0`, kustomize starts at `v1.6.1` |
| `wled-mock` | `v0.3.0` | **`v0.7.4`** | both artifacts start at `v0.4.1` |
| `led-catcher` | `latest` | **`v0.2.2`** | kustomize never published a `latest` tag |

**Staying inside the major line is deliberate.** `demo-pitcher v2.0.0` and `wled-mock v1.0.0` both exist, but adopting them is a behaviour change rather than a repair — and that is not mine to decide. Renovate now sees these components (#206) and will propose those majors as labelled, non-automerged PRs for a human to weigh.

Pinning `led-catcher` also removes a floating `latest`, which defeated pinning and was invisible to Renovate.

## clusterscope

`clusterscope-kustomize-multi-repo` returns **403** — private, renamed, or never published — so its `OCIRepository` and `Kustomization` cannot ever succeed. Both are **suspended**, not deleted, so the configuration survives for whoever republishes the artifact.

Worth flagging: the file claimed these are gated by `CLUSTERSCOPE_MULTI_REPO=enabled`, but no such gate exists in the manifest — `suspend` was simply commented out, so both resources were reconciling unconditionally against a 403.

## Verification

```
task verify-image-tags   ->  OK: all 34 substituted image tags exist   (exit 0)
kustomize build          ->  clusterscope, demo-pitcher, wled-mock, led-catcher all OK
```

clusterscope is still listed, correctly, under *unreadable* rather than *missing* — a 403 is not evidence of a broken tag.

## Not fixed here

The structural question from #208 stays open: whether `<component>` and `<component>-kustomize` should be released in lockstep, or get separate variables. This PR repairs the state, not the release process — as long as the two artifacts can drift, a single variable will break again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi