### PR TITLE
feat(renovate): group homerun2 updates per component instead of one bulk PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,3 +195,21 @@ written back exactly as the registry publishes it — `v0.5.0` stays `v0.5.0`,
 
 `task verify-image-tags` resolves every substituted default against the real
 registry and is the check that catches this class of breakage.
+
+### homerun2 components group per component
+
+Each homerun2 component ships two artifacts — the image and its `-kustomize` OCI
+artifact — driven by one substitution variable. If Renovate bumped them in
+separate PRs they could be merged apart, and a variable pointing at a tag only
+one of them has resolves to nothing (this is what broke `demo-pitcher`, #208).
+
+A `packageRule` therefore groups them by component, so both always move in the
+same PR:
+
+```json
+"groupName": "homerun2 {{{replace '-kustomize$' '' (replace '^ghcr\\.io/stuttgart-things/homerun2-' '' depName)}}}"
+```
+
+It sits after the broad `stuttgart-things images` rule and overrides it for
+`homerun2-**`; everything else stays in the combined group. Verify group names
+with `task preview-renovate` — they appear as branch names before any PR exists.

--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,16 @@
       "groupName": "stuttgart-things images"
     },
     {
+      "description": "Group each homerun2 component on its own, so a component's image and its -kustomize artifact are always bumped in the same PR and cannot drift apart (see #208). Overrides the broad stuttgart-things grouping above.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/stuttgart-things/homerun2-**"
+      ],
+      "groupName": "homerun2 {{{replace '-kustomize$' '' (replace '^ghcr\\.io/stuttgart-things/homerun2-' '' depName)}}}"
+    },
+    {
       "description": "Auto-merge patch and digest updates once CI passes \u2014 keeps low-risk bumps from piling up",
       "matchUpdateTypes": [
         "patch",


### PR DESCRIPTION
## Problem

The `stuttgart-things images` rule matches `ghcr.io/stuttgart-things/**` and puts every first-party image into a **single** PR. With the homerun2 components now visible (#206), that PR carries **23 packages** — 18 of them homerun2 — bumping nine services at once:

| Queued PR | Packages | of which homerun2 |
|---|---|---|
| `stuttgart-things images` | 23 | 18 |
| `stuttgart-things images (major)` | 15 | 13 |

Hard to review, and one bad component blocks the other 22.

## Change

A rule that groups homerun2 packages **by component**:

```json
{
  "matchDatasources": ["docker"],
  "matchPackageNames": ["ghcr.io/stuttgart-things/homerun2-**"],
  "groupName": "homerun2 {{{replace '-kustomize$' '' (replace '^ghcr\\.io/stuttgart-things/homerun2-' '' depName)}}}"
}
```

It sits after the broad rule and overrides it for `homerun2-**`. Everything else — clusterbook, `charts/*`, homerun — stays in the combined group.

## This also closes the drift behind #208

Each homerun2 component ships two artifacts, the image and its `-kustomize` OCI artifact, driven by **one** substitution variable. In separate PRs they could be merged apart, leaving the variable pointing at a tag only one artifact has.

That is precisely how `demo-pitcher` ended up pinned at `v1.4.0` while its kustomize artifact starts at `v1.6.1`. Grouping by component makes it structurally impossible — both always move in the same PR.

## Verification

`task preview-renovate`:

```
homerun2-core-catcher            major-homerun2-core-catcher
homerun2-git-pitcher             major-homerun2-demo-pitcher
homerun2-k8s-pitcher             major-homerun2-git-pitcher
homerun2-light-catcher           major-homerun2-k8s-pitcher
homerun2-notification-catcher    major-homerun2-light-catcher
homerun2-omni-pitcher            major-homerun2-notification-catcher
homerun2-scout                   major-homerun2-omni-pitcher
                                 major-homerun2-scout
                                 major-homerun2-wled-mock
```

2 bulk groups become 7 non-major + 9 major per-component groups. Total prospective branches go from 39 to 53 — same updates, split up.

**No branch carries `-kustomize` in its name**, which is the proof the artifacts are grouped in rather than split out: an ungrouped `homerun2-scout-kustomize` would have produced its own branch. Confirmed directly too — the `renovate/homerun2-scout` block lists `ghcr.io/stuttgart-things/homerun2-scout-kustomize` among its upgrades.

`demo-pitcher` and `wled-mock` appear only under `major-` because #209 already moved them to the newest version in their current major line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi