### PR TITLE
ci: gate pull requests on the renovate checks

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,69 @@
+---
+# Pre-merge gate for the Renovate wiring.
+#
+# Both failure modes this guards against are silent: a HelmRelease whose chart
+# version carries no "# renovate:" annotation is skipped by Renovate without a
+# warning and simply never updates, and a substituted image tag that does not
+# exist in its registry only fails once a cluster tries to pull it.
+#
+# The checks are invoked as scripts rather than through `task`, on purpose: the
+# Taskfile includes a remote Taskfile, which task refuses to load unattended
+# ("not trusted by user") unless passed --yes — and --yes would mean trusting a
+# Taskfile fetched over the network on every CI run. The scripts under hack/ are
+# what the task targets call anyway, so both paths run identical code.
+#
+# Deliberately not run here: `task preview-renovate`, a full Renovate run taking
+# minutes. Use it locally when changing renovate.json.
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  annotations:
+    name: Chart version annotations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Every substituted chart version is annotated
+        run: ./hack/check-chart-annotations.sh
+
+  image-tags:
+    name: Image tags resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Queries ghcr.io and docker.io tag listings. Repositories that cannot be
+      # read are reported separately and do not fail the job, so a private or
+      # renamed package is never mistaken for a broken tag.
+      - name: Every substituted image tag exists
+        run: python3 hack/verify-image-tags.py
+
+  renovate-config:
+    name: Renovate config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # renovate declares engines.node ^24.11.0; an older runtime happens to work
+      # for the validator today but is not something to rely on.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      # npx rather than the renovate/renovate image the lint-renovate task uses:
+      # several GB of pull for a single validation is not worth it in CI.
+      # Validating against @latest is intentional — that is what Mend Cloud runs.
+      - name: Validate renovate.json
+        run: npx --yes --package renovate@latest renovate-config-validator renovate.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,18 @@ Flux decryption is wired via the `sops-age` secret in `flux-system` and a kustom
 
 Run `pre-commit run --all-files` to validate before pushing. Active checks: trailing whitespace, end-of-file-fixer, large files, merge conflicts, symlinks, private key detection, shellcheck, hadolint, GitHub Actions schema validation, and high-entropy secret detection.
 
+## CI Gate
+
+`.github/workflows/validate.yaml` runs on every pull request and blocks the merge on three jobs:
+
+| Job | Runs |
+|---|---|
+| Chart version annotations | `hack/check-chart-annotations.sh` |
+| Image tags resolve | `hack/verify-image-tags.py` |
+| Renovate config | `renovate-config-validator` on Node 24 |
+
+The workflow calls the scripts directly rather than going through `task`. The Taskfile includes a remote Taskfile, which `task` refuses to load unattended (`not trusted by user`, exit 104) unless given `--yes` — and that would mean trusting a network-fetched Taskfile on every CI run. The `task` targets call the same scripts, so local and CI run identical code.
+
 ## Dependency Management
 
 Renovate is configured (`renovate.json`) with Flux-specific YAML file matching to automatically propose version updates for Helm charts and OCI artifacts.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -140,33 +140,7 @@ tasks:
     desc: Fail if a substituted HelmRelease chart version lacks its "# renovate:" annotation
     silent: true
     cmds:
-      - |
-        # Renovate's flux manager cannot parse ${VAR:-1.2.3} in chart.spec.version;
-        # it drops the dep as "contains-variable" without warning. The annotation on
-        # the preceding line is what feeds the custom manager instead — so a missing
-        # one means that chart silently never gets an update PR.
-        missing=$(find apps infra cicd -name '*.yaml' -print0 \
-          | xargs -0 awk '
-              FNR == 1 { prev = "" }
-              /^[[:space:]]*version:[[:space:]]*\$\{[A-Z0-9_]+:-/ {
-                if (prev !~ /#[[:space:]]*renovate:/) printf "  %s:%d\n", FILENAME, FNR
-              }
-              { prev = $0 }
-            ')
-
-        if [ -n "${missing}" ]; then
-          echo "Chart versions with no '# renovate:' annotation:"
-          echo "${missing}"
-          echo
-          echo "Renovate will never propose an update for these."
-          echo "Derive the annotation from the HelmRepository the sourceRef points at:"
-          echo "  type: oci   -> # renovate: datasource=docker depName=<host>/<path>/<chart>"
-          echo "  plain HTTPS -> # renovate: datasource=helm depName=<chart> registryUrl=<url>"
-          echo "See CLAUDE.md -> Dependency Management."
-          exit 1
-        fi
-
-        echo "OK: every substituted chart version is annotated."
+      - ./hack/check-chart-annotations.sh {{.CLI_ARGS}}
 
   verify-image-tags:
     desc: Check that every substituted image tag / OCIRepository ref exists in its registry

--- a/hack/check-chart-annotations.sh
+++ b/hack/check-chart-annotations.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Fail if a HelmRelease chart version behind Flux variable substitution is
+# missing its "# renovate:" annotation.
+#
+# Renovate's flux manager cannot parse ${VAR:-1.2.3} in chart.spec.version; it
+# drops the dep as "contains-variable" without a warning, so the chart simply
+# never gets an update PR. The annotation on the preceding line is what feeds
+# the custom manager instead.
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  roots=("$@")
+else
+  roots=(apps infra cicd)
+fi
+
+# shellcheck disable=SC2016  # the awk program must not be expanded by the shell
+missing=$(find "${roots[@]}" -name '*.yaml' -print0 \
+  | xargs -0 awk '
+      FNR == 1 { prev = "" }
+      /^[[:space:]]*version:[[:space:]]*\$\{[A-Z0-9_]+:-/ {
+        if (prev !~ /#[[:space:]]*renovate:/) printf "  %s:%d\n", FILENAME, FNR
+      }
+      { prev = $0 }
+    ')
+
+if [ -n "${missing}" ]; then
+  echo "Chart versions with no '# renovate:' annotation:"
+  echo "${missing}"
+  echo
+  echo "Renovate will never propose an update for these."
+  echo "Derive the annotation from the HelmRepository the sourceRef points at:"
+  echo "  type: oci   -> # renovate: datasource=docker depName=<host>/<path>/<chart>"
+  echo "  plain HTTPS -> # renovate: datasource=helm depName=<chart> registryUrl=<url>"
+  echo "See CLAUDE.md -> Dependency Management."
+  exit 1
+fi
+
+echo "OK: every substituted chart version is annotated."


### PR DESCRIPTION
Both failure modes these guard against are **silent, and invisible in a diff review**:

- A HelmRelease whose chart version has no `# renovate:` annotation is skipped by Renovate with no warning and simply never updates. That is how 43 charts went unnoticed for months (#203).
- A substituted image tag that does not exist in its registry only fails once a cluster tries to pull it. That is how velero, clusterbook and run-things ended up pointing at nothing (#207, #209).

## The gate

`.github/workflows/validate.yaml`, on `pull_request` and on push to `main`:

| Job | Runs | Needs |
|---|---|---|
| Chart version annotations | `hack/check-chart-annotations.sh` | nothing |
| Image tags resolve | `hack/verify-image-tags.py` | network |
| Renovate config | `renovate-config-validator` | Node 24 |

`preview-renovate` is deliberately **not** in the gate — a full Renovate run takes minutes and belongs in a local loop.

## Why it does not use `task`

The Taskfile includes a remote Taskfile. `task` refuses to load that unattended:

```
task: Taskfile "https://raw.githubusercontent.com/stuttgart-things/tasks/.../git.yaml" not trusted by user
exit 104
```

Verified against a fresh checkout with no `.task` cache — a `task`-based workflow would have been red on every PR.

`--yes` would silence it, but that means trusting a Taskfile fetched over the network on every CI run. So the annotation check moves out of the Taskfile into `hack/check-chart-annotations.sh`, and the task target now calls it too — CI and local run identical code rather than two copies of one awk program.

## Two smaller calls

**Node 24**, because renovate declares `engines.node ^24.11.0`. Node 20 happens to work for the validator today, but the full renovate binary already fails on it (`RegExp.escape is not a function`) — so that is luck, not support.

**npx, not the `renovate/renovate` image** that `task lint-renovate` uses: several GB of pull for one validation is not worth it per PR. Validating against `@latest` is intentional, since that is what Mend Cloud runs against this repo.

## Verification

Against a clean checkout, all three jobs pass. And — the part that actually matters for a gate — both fail when they should:

```
# annotation removed from infra/cert-manager/release.yaml
Chart versions with no '# renovate:' annotation:
  infra/cert-manager/release.yaml:12
exit 1

# homerun2-scout pointed at v9.9.9
apps/homerun2/components/scout/release.yaml:52  ghcr.io/stuttgart-things/homerun2-scout:v9.9.9 does not exist
exit 1
```

A gate that only passes is not a gate.

## After merging

The jobs need to be added as required status checks in branch protection for `main` before they actually block anything — that is a repo setting, not something this PR can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi