### PR TITLE
ci(release): push the CHANGELOG with RELEASE_TOKEN so the ruleset can enforce

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,11 +62,22 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0     # full history so commit-analyzer sees every commit
+          # Leave the checkout token out of .git/config so the push below uses
+          # RELEASE_TOKEN rather than the job's GITHUB_TOKEN.
+          persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:
           node-version: lts/*
 
+      # @semantic-release/git pushes the CHANGELOG commit straight to main. The
+      # ruleset on main requires status checks, and GITHUB_TOKEN cannot bypass
+      # it: bypass_actors only accepts an Integration that belongs to the owner
+      # organization, and org-level rulesets need GitHub Team. A PAT belonging to
+      # a repository admin does bypass it, since admins are in the bypass list.
+      #
+      # Falls back to GITHUB_TOKEN so the workflow still runs where RELEASE_TOKEN
+      # is absent — that combination cannot push once the ruleset is enforcing.
       - name: semantic-release
         id: semantic
         uses: cycjimmy/semantic-release-action@v6.0.0
@@ -76,7 +87,7 @@ jobs:
             @semantic-release/changelog
             @semantic-release/git
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   plan:
     name: plan OCI push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,28 @@ Run `pre-commit run --all-files` to validate before pushing. Active checks: trai
 
 The workflow calls the scripts directly rather than going through `task`. The Taskfile includes a remote Taskfile, which `task` refuses to load unattended (`not trusted by user`, exit 104) unless given `--yes` — and that would mean trusting a network-fetched Taskfile on every CI run. The `task` targets call the same scripts, so local and CI run identical code.
 
+### Why the release needs `RELEASE_TOKEN`
+
+A ruleset on `main` makes those three checks required. `@semantic-release/git`
+pushes the CHANGELOG commit straight to `main`, and a required-status-check rule
+blocks any push whose commit has no passing checks — verified: the push is
+rejected with `GH013: Repository rule violations found`.
+
+`GITHUB_TOKEN` cannot be exempted. A ruleset's `bypass_actors` only accepts an
+Integration belonging to the owner organization, and org-level rulesets (where
+GitHub Actions could be listed) require GitHub Team.
+
+A PAT belonging to a repository admin does bypass it, because the admin role is
+in the bypass list. Hence `secrets.RELEASE_TOKEN` — a fine-grained PAT on this
+repo with **Contents: read and write** (plus Issues and Pull requests: read and
+write for semantic-release's comments). The checkout in that job sets
+`persist-credentials: false` so the push uses that token rather than the job's
+`GITHUB_TOKEN`.
+
+The workflow falls back to `GITHUB_TOKEN` when `RELEASE_TOKEN` is absent, so it
+still runs — but that combination cannot push once the ruleset is enforcing.
+Remember the PAT expires; the release job fails at the push step when it does.
+
 ## Dependency Management
 
 Renovate is configured (`renovate.json`) with Flux-specific YAML file matching to automatically propose version updates for Helm charts and OCI artifacts.


### PR DESCRIPTION
The validation gate from #213 is only advisory until a ruleset on `main` makes the three checks **required**. This PR unblocks that.

## The conflict

A required-status-check rule blocks any push whose commit has no passing checks. `@semantic-release/git` pushes the CHANGELOG commit **straight to main**. Enforcing the rule as-is would fail every release at the push step.

Verified rather than assumed — a probe ruleset with one required check and no bypass actors, on a throwaway branch:

```
remote: error: GH013: Repository rule violations found for refs/heads/probe/ruleset
remote: - Required status check "Chart version annotations" is expected.
 ! [remote rejected] probe/ruleset (push declined due to repository rule violations)
```

## Why GITHUB_TOKEN cannot just be exempted

A ruleset's `bypass_actors` only accepts an Integration belonging to the owner organization. Adding GitHub Actions at repo level:

```
Actor GitHub Actions integration must be part of the ruleset source or owner organization  (422)
```

Org-level rulesets, where it *could* be listed, need GitHub Team:

```
Upgrade to GitHub Team to enable this feature.  (403)
```

A PAT belonging to a repository admin **does** bypass it, because the admin role is in the bypass list.

## Change

- `GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}`
- `persist-credentials: false` on that job's checkout, so the push uses `RELEASE_TOKEN` rather than the job's `GITHUB_TOKEN` left in `.git/config`

**Merging this alone changes nothing.** The fallback keeps current behaviour until the secret exists, and the ruleset stays in `evaluate` mode meanwhile.

## What you need to do

1. Create a fine-grained PAT on `stuttgart-things/flux` with **Contents: read and write**, plus **Issues** and **Pull requests: read and write** for semantic-release's comments.
2. Add it as repository secret **`RELEASE_TOKEN`**.
3. Tell me, and I flip the ruleset from `evaluate` to `active`.

Note the PAT expires — when it does, the release job fails at the push step. Worth a calendar entry, or use the longest expiry your policy allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PioA2K1dcNNGZwcEeb3PKi